### PR TITLE
Search Space produces better results with package.name checks

### DIFF
--- a/vdb/lib/db.py
+++ b/vdb/lib/db.py
@@ -166,10 +166,7 @@ def bulk_index_search(pkg_list):
         version_list = None
         vendor_idx_key = None
         # If there is vendor information use it to perform strict search
-        if pkg.get("vendor"):
-            vendor_idx_key = pkg.get("vendor").lower() + "|" + pkg["name"].lower()
-            version_list = vendor_index_data.get(vendor_idx_key, [])
-        else:
+        if pkg.get("name"):
             version_list = index_data.get(pkg["name"].lower(), [])
         for vers in version_list:
             vrange = vers.split("-")


### PR DESCRIPTION
The underlying issue seems to still not be solved with adding more package specific names https://github.com/AppThreat/dep-scan/issues/23.

When adding new packages to requirements.txt, this seems to fail. As an example, scan now fails to detect the following packages as an example:
```
tensorflow
ansible
```
Searching in terms of package name seems to produce better results at least for `requirements.txt`. This shouldn't break other language dependencies in lock files ideally.