### PR TITLE
Support GHE

### DIFF
--- a/vdb/lib/config.py
+++ b/vdb/lib/config.py
@@ -9,7 +9,7 @@ nvd_url = "https://nvd.nist.gov/feeds/json/cve/1.1/nvdcve-1.1-%(year)s.json.gz"
 nvd_start_year = os.getenv("NVD_START_YEAR", 2016)
 
 # GitHub advisory feed url
-gha_url = "https://api.github.com/graphql"
+gha_url = os.getenv("GITHUB_GRAPHQL_URL", "https://api.github.com/graphql")
 
 # No of pages to download from GitHub during a full refresh
 gha_pages_count = os.getenv("GITHUB_PAGE_COUNT", 10)

--- a/vdb/lib/gha.py
+++ b/vdb/lib/gha.py
@@ -203,6 +203,8 @@ class GitHubSource(NvdSource):
             if isinstance(references, bytes):
                 references = references.decode("utf-8", "ignore")
             for p in cve["vulnerabilities"]["nodes"]:
+                if not p:
+                    continue
                 vendor = p["package"]["ecosystem"]
                 product = p["package"]["name"]
                 if ":" in product or "/" in product:


### PR DESCRIPTION
This adds support for GitHub Enterprise instances. The extra check is just to avoid database hickups as GitHub returns sometimes non-existent nodes.

This is required by: https://github.com/ShiftLeftSecurity/sast-scan/pull/344