### PR TITLE
Handle NPM advisory returning a `null` value instead of a json object

### DIFF
--- a/vdb/lib/npm.py
+++ b/vdb/lib/npm.py
@@ -203,8 +203,9 @@ class NpmSource(NvdSource):
                 severity
             )
             exploitabilityScore = score
-            if v.get("metadata") and v.get("metadata").get("exploitability"):
-                exploitabilityScore = v.get("metadata").get("exploitability")
+            metadata = v.get('metadata', {})
+            if isinstance(metadata, dict) and metadata.get("exploitability"):
+                exploitabilityScore = metadata.get("exploitability")
             cwe_id = v.get("cwe")
             version = v["vulnerable_versions"]
             fix_version = v.get("patched_versions")


### PR DESCRIPTION
Do to what I believe is the migration to Github for npm advisories, the API appears to have changed. The `metadata` (as well as the `npm_advisory_id`) field can now return `null`.

This pull request attempts to address checking if when getting `metadata` from the vulnerability object is a dictionary and if it is then continue on getting the exploitability score.

Example vulnerability for `set-value` that shoes `metadata` is set to `null`
```
{
    "access": "public",
    "created": "2021-10-07T07:31:50.512Z",
    "cves": [
        "CVE-2021-23440"
    ],
    "cwe": "CWE-843",
    "deleted": null,
    "findings": [
        {
            "paths": [
                "set-value"
            ],
            "version": "2.0.1"
        }
    ],
    "found_by": null,
    "github_advisory_id": "GHSA-4jqc-8m5r-9rpr",
    "id": 1002475,
    "metadata": null,
    "module_name": "set-value",
    "npm_advisory_id": null,
    "overview": "This affects the package set-value before 4.0.1. A type confusion vulnerability can lead to a bypass of CVE-2019-10747 when the user-provided keys used in the path parameter are arrays.",
    "patched_versions": ">=4.0.1",
    "recommendation": "Upgrade to version 4.0.1 or later",
    "references": "- https://nvd.nist.gov/vuln/detail/CVE-2021-23440\n- https://github.com/advisories/GHSA-4jqc-8m5r-9rpr",
    "reported_by": null,
    "severity": "high",
    "title": "Prototype Pollution in set-value",
    "updated": "2021-09-13T19:33:19.000Z",
    "url": "https://github.com/advisories/GHSA-4jqc-8m5r-9rpr",
    "vulnerable_versions": "<4.0.1"
}
```