### PR TITLE
Wolfi OS + Go namespace to name move

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This repo is a vulnerability database and package search for sources such as Aqu
 - Ubuntu
 - OpenSUSE/SLES
 - Photon
+- Chainguard
+- Wolfi OS
 
 ## Installation
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="appthreat-vulnerability-db",
-    version="5.0.4",
+    version="5.1.0",
     author="Team AppThreat",
     author_email="cloud@appthreat.com",
     description="AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities.",

--- a/test/data/protobuf-c.json
+++ b/test/data/protobuf-c.json
@@ -1,0 +1,15 @@
+{
+  "name": "protobuf-c",
+  "secfixes": {
+    "1.4.1-r0": [
+      "CVE-2022-33070",
+      "CVE-2021-3121"
+    ]
+  },
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "x86_64"
+  ],
+  "urlprefix": "https://packages.wolfi.dev",
+  "reponame": "os"
+}

--- a/test/data/redis.json
+++ b/test/data/redis.json
@@ -1,0 +1,31 @@
+{
+  "name": "redis",
+  "secfixes": {
+    "7.0.10-r0": [
+      "CVE-2023-28425"
+    ],
+    "7.0.11-r0": [
+      "CVE-2023-28856"
+    ],
+    "7.0.7-r0": [
+      "CVE-2022-0543",
+      "CVE-2022-3734",
+      "CVE-2022-3647"
+    ],
+    "7.0.8-r0": [
+      "CVE-2022-35977",
+      "CVE-2023-22458"
+    ],
+    "7.0.9-r0": [
+      "CVE-2022-36021",
+      "CVE-2023-25155"
+    ]
+  },
+  "apkurl": "{{urlprefix}}/{{reponame}}/{{arch}}/{{pkg.name}}-{{pkg.ver}}.apk",
+  "archs": [
+    "aarch64",
+    "x86_64"
+  ],
+  "urlprefix": "https://packages.cgr.dev",
+  "reponame": "chainguard"
+}

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -469,7 +469,7 @@ def test_wolfi_convert(test_aqua_cg_json, test_aqua_wolfi_json):
     aqualatest = AquaSource()
     cve_data = aqualatest.convert(test_aqua_cg_json)
     assert cve_data
-    assert len(cve_data) == 1
+    assert len(cve_data) == 9
     cve_data = aqualatest.convert(test_aqua_wolfi_json)
     assert cve_data
-    assert len(cve_data) == 1
+    assert len(cve_data) == 2

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -263,6 +263,24 @@ def test_aqua_debian7_json():
         return json.loads(fp.read())
 
 
+@pytest.fixture
+def test_aqua_cg_json():
+    test_cve_data = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "data", "redis.json"
+    )
+    with open(test_cve_data, "r") as fp:
+        return json.loads(fp.read())
+
+
+@pytest.fixture
+def test_aqua_wolfi_json():
+    test_cve_data = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "data", "protobuf-c.json"
+    )
+    with open(test_cve_data, "r") as fp:
+        return json.loads(fp.read())
+
+
 def test_convert(test_cve_json):
     nvdlatest = NvdSource()
     data = nvdlatest.convert(test_cve_json)
@@ -445,3 +463,13 @@ def test_ubuntu_convert(test_aqua_ubuntu4_json, test_aqua_ubuntu5_json):
     cve_data = aqualatest.convert(test_aqua_ubuntu5_json)
     assert cve_data
     assert len(cve_data) == 7
+
+
+def test_wolfi_convert(test_aqua_cg_json, test_aqua_wolfi_json):
+    aqualatest = AquaSource()
+    cve_data = aqualatest.convert(test_aqua_cg_json)
+    assert cve_data
+    assert len(cve_data) == 1
+    cve_data = aqualatest.convert(test_aqua_wolfi_json)
+    assert cve_data
+    assert len(cve_data) == 1

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -629,3 +629,48 @@ def test_ubuntu_versions():
     assert utils.convert_to_semver("1.5.dfsg+1.5.0.13~prepatch070731-0ubuntu1")[0]
     assert utils.convert_to_semver("01.03.00.99.svn.300-3")[0]
     assert utils.checkEpoch("1:1.1.1k-7.el8_6")
+
+
+def test_parse_purl():
+    assert utils.parse_purl(
+        "pkg:maven/org.jenkins-ci.plugins/JDK_Parameter_Plugin"
+    ) == {
+        "type": "maven",
+        "namespace": "org.jenkins-ci.plugins",
+        "name": "JDK_Parameter_Plugin",
+        "version": None,
+        "qualifiers": None,
+        "subpath": None,
+    }
+    assert utils.parse_purl("pkg:golang/github.com/sjqzhang/go-fastdfs") == {
+        "type": "golang",
+        "namespace": "",
+        "name": "github.com/sjqzhang/go-fastdfs",
+        "version": None,
+        "qualifiers": None,
+        "subpath": None,
+    }
+    assert utils.parse_purl("pkg:golang/vitess.io/vitess") == {
+        "type": "golang",
+        "namespace": "",
+        "name": "vitess.io/vitess",
+        "version": None,
+        "qualifiers": None,
+        "subpath": None,
+    }
+    assert utils.parse_purl("pkg:golang/stdlib") == {
+        "type": "golang",
+        "namespace": None,
+        "name": "stdlib",
+        "version": None,
+        "qualifiers": None,
+        "subpath": None,
+    }
+    assert utils.parse_purl("pkg:golang/github.com/containerd/containerd") == {
+        "type": "golang",
+        "namespace": "",
+        "name": "github.com/containerd/containerd",
+        "version": None,
+        "qualifiers": None,
+        "subpath": None,
+    }

--- a/vdb/lib/aqua.py
+++ b/vdb/lib/aqua.py
@@ -878,26 +878,26 @@ class AquaSource(NvdSource):
         return ret_data
 
     def wolfi_to_vuln(self, cve_data):
-        """Wolfi OS and ChainGuard"""
+        """Wolfi OS and Chainguard"""
         ret_data = []
-        cve_id = ""
         cwe_id = ""
         references = []
         assigner = cve_data.get("reponame")
-        severity = threat_to_severity[cve_data.get("severity").lower()]
+        # No severity of any kind in the advisories
+        severity = "LOW"
         score, severity, vectorString, attackComplexity = get_default_cve_data(severity)
         publishedDate = ""
         lastModifiedDate = ""
-        for pkg_name in packages:
-            version_start_including = ""
-            version_end_including = cve_data.get("affected")
-            version_start_excluding = ""
-            version_end_excluding = cve_data.get("fixed")
-            fix_version_end_including = ""
-            fix_version_start_excluding = ""
-            fix_version_end_excluding = ""
-            fix_version_start_including = cve_data.get("fixed")
-            if pkg_name and version_end_including:
+        pkg_name = cve_data.get("name")
+        for fix_version_start_including, cve_list in cve_data.get("secfixes").items():
+            for cve_id in cve_list:
+                version_start_including = ""
+                version_end_including = ""
+                version_start_excluding = ""
+                version_end_excluding = fix_version_start_including
+                fix_version_end_including = ""
+                fix_version_start_excluding = ""
+                fix_version_end_excluding = ""
                 tdata = config.CVE_TPL % dict(
                     cve_id=cve_id,
                     cwe_id=cwe_id,
@@ -905,7 +905,7 @@ class AquaSource(NvdSource):
                     references=references,
                     description="",
                     vectorString=vectorString,
-                    vendor="arch",
+                    vendor=assigner,
                     product=pkg_name,
                     version="*",
                     edition="*",
@@ -926,7 +926,7 @@ class AquaSource(NvdSource):
                 )
                 try:
                     vuln = NvdSource.convert_vuln(json_lib.loads(tdata))
-                    vuln.description = description
+                    vuln.description = f"""URL Prefix: {cve_data.get("urlprefix")}. Affected arch: {", ".join(cve_data.get("archs"))}"""
                     ret_data.append(vuln)
                 except Exception:
                     pass

--- a/vdb/lib/aqua.py
+++ b/vdb/lib/aqua.py
@@ -113,6 +113,8 @@ class AquaSource(NvdSource):
             return self.photon_to_vuln(cve_data)
         elif cve_data.get("Annotations") and cve_data.get("Header"):
             return self.debian_to_vuln(cve_data)
+        elif cve_data.get("secfixes"):
+            return self.wolfi_to_vuln(cve_data)
         return []
 
     def is_supported_source(self, zfname):
@@ -852,6 +854,61 @@ class AquaSource(NvdSource):
                     product=pkg_name,
                     version="*",
                     edition=distro_name if distro_name else "*",
+                    version_start_including=version_start_including,
+                    version_end_including=version_end_including,
+                    version_start_excluding=version_start_excluding,
+                    version_end_excluding=version_end_excluding,
+                    fix_version_start_including=fix_version_start_including,
+                    fix_version_end_including=fix_version_end_including,
+                    fix_version_start_excluding=fix_version_start_excluding,
+                    fix_version_end_excluding=fix_version_end_excluding,
+                    severity=severity,
+                    attackComplexity=attackComplexity,
+                    score=score,
+                    exploitabilityScore=score,
+                    publishedDate=publishedDate,
+                    lastModifiedDate=lastModifiedDate,
+                )
+                try:
+                    vuln = NvdSource.convert_vuln(json_lib.loads(tdata))
+                    vuln.description = description
+                    ret_data.append(vuln)
+                except Exception:
+                    pass
+        return ret_data
+
+    def wolfi_to_vuln(self, cve_data):
+        """Wolfi OS and ChainGuard"""
+        ret_data = []
+        cve_id = ""
+        cwe_id = ""
+        references = []
+        assigner = cve_data.get("reponame")
+        severity = threat_to_severity[cve_data.get("severity").lower()]
+        score, severity, vectorString, attackComplexity = get_default_cve_data(severity)
+        publishedDate = ""
+        lastModifiedDate = ""
+        for pkg_name in packages:
+            version_start_including = ""
+            version_end_including = cve_data.get("affected")
+            version_start_excluding = ""
+            version_end_excluding = cve_data.get("fixed")
+            fix_version_end_including = ""
+            fix_version_start_excluding = ""
+            fix_version_end_excluding = ""
+            fix_version_start_including = cve_data.get("fixed")
+            if pkg_name and version_end_including:
+                tdata = config.CVE_TPL % dict(
+                    cve_id=cve_id,
+                    cwe_id=cwe_id,
+                    assigner=assigner,
+                    references=references,
+                    description="",
+                    vectorString=vectorString,
+                    vendor="arch",
+                    product=pkg_name,
+                    version="*",
+                    edition="*",
                     version_start_including=version_start_including,
                     version_end_including=version_end_including,
                     version_start_excluding=version_start_excluding,

--- a/vdb/lib/utils.py
+++ b/vdb/lib/utils.py
@@ -967,9 +967,17 @@ def convert_md_references(md_text):
 
 def parse_purl(purl_str):
     """Method to parse a package url string safely"""
+    purl_obj = None
     try:
-        return PackageURL.from_string(purl_str).to_dict() if purl_str else None
+        purl_obj = PackageURL.from_string(purl_str).to_dict() if purl_str else None
+        # For golang, move everything to name since there is no concept of namespace
+        if purl_obj and purl_obj.get("type") == "golang" and purl_obj.get("namespace"):
+            purl_obj["name"] = f'{purl_obj["namespace"]}/{purl_obj["name"]}'
+            purl_obj["namespace"] = ""
     except ValueError:
+        # Ignore errors
+        pass
+    if not purl_obj and purl_str:
         tmpA = purl_str.split("@")[0]
         purl_obj = {}
         if tmpA:
@@ -983,7 +991,7 @@ def parse_purl(purl_str):
                     if tmpB[-2].startswith("pkg:"):
                         namespace = tmpB[-2].split(":")[-1]
                     purl_obj["namespace"] = namespace
-        return purl_obj
+    return purl_obj
 
 
 def convert_score_severity(score):


### PR DESCRIPTION
- Wolfi OS
- Chainguard
- Move namespace to name field for go (Since golang doesn't have a concept of namespace so AppThreat was deviating from other tools such as dependency-track)
