### PR TITLE
Allow later semver

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,6 @@ appdirs
 tabulate
 msgpack==1.0.5
 orjson
-semver==2.13.0
+semver>=3.0.0
 packageurl-python
 cvss

--- a/vdb/lib/utils.py
+++ b/vdb/lib/utils.py
@@ -263,9 +263,9 @@ def normalise_version_str(version_num, normal_len):
 def semver_compatible(compare_ver, min_version, max_version):
     """Method to check if all version numbers are semver compatible"""
     return (
-        VersionInfo.isvalid(compare_ver)
-        and VersionInfo.isvalid(min_version)
-        and VersionInfo.isvalid(max_version)
+        VersionInfo.is_valid(compare_ver)
+        and VersionInfo.is_valid(min_version)
+        and VersionInfo.is_valid(max_version)
     )
 
 
@@ -597,7 +597,7 @@ def version_compare(
             ):
                 return False
             if max_affected_version_excluding:
-                if VersionInfo.isvalid(compare_ver) and VersionInfo.isvalid(
+                if VersionInfo.is_valid(compare_ver) and VersionInfo.is_valid(
                     max_affected_version_excluding
                 ):
                     cmp_value = VersionInfo.parse(compare_ver).compare(
@@ -643,9 +643,9 @@ def version_compare(
     # If compare_ver is semver compatible and min_version is * then max_version should be semver compatible
     if (
         compare_ver
-        and VersionInfo.isvalid(compare_ver)
+        and VersionInfo.is_valid(compare_ver)
         and (not min_version or min_version == "*")
-        and not VersionInfo.isvalid(max_version)
+        and not VersionInfo.is_valid(max_version)
     ):
         return False
     # Perform semver match once we have all the required versions


### PR DESCRIPTION
[`semver-3.0.0`](https://python-semver.readthedocs.io/en/latest/changelog.html#version-3-0-0) has breaking changes.. Especially `isvalid` was renamed to `is_valid`.