### PR TITLE
Support for searching os packages without vendor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "5.2.0"
+version = "5.2.1"
 description = "AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -3,10 +3,10 @@ import os
 
 import pytest
 
+from vdb.lib.aqua import AquaSource
 from vdb.lib.gha import GitHubSource
 from vdb.lib.nvd import NvdSource
 from vdb.lib.osv import OSVSource
-from vdb.lib.aqua import AquaSource
 
 
 @pytest.fixture

--- a/vdb/lib/config.py
+++ b/vdb/lib/config.py
@@ -61,6 +61,7 @@ osv_url_dict = {
     "linux": "https://osv-vulnerabilities.storage.googleapis.com/Linux/all.zip",
     "debian": "https://osv-vulnerabilities.storage.googleapis.com/Debian/all.zip",
     "oss-fuzz": "https://osv-vulnerabilities.storage.googleapis.com/OSS-Fuzz/all.zip",
+    "cran": "https://osv-vulnerabilities.storage.googleapis.com/CRAN/all.zip",
 }
 
 aquasec_vuln_list_url = (

--- a/vdb/lib/db.py
+++ b/vdb/lib/db.py
@@ -151,21 +151,32 @@ def _key_func(data, match_list):
                 max_affected_version_excluding,
             ):
                 return True
-        # Search by vendor, name and version
+        # Search by pos or vendor, name and version
         if len(name_ver) == 3:
-            # Check if we have a hit
-            if (
-                name_ver[0] == vendor
-                and name_ver[1] == package
-                and version_compare(
+            # Is name_ver[0] pos?
+            if "_" in name_ver[0]:
+                if name_ver[1] == package and version_compare(
                     name_ver[2],
                     min_affected_version_including,
                     max_affected_version_including,
                     min_affected_version_excluding,
                     max_affected_version_excluding,
-                )
-            ):
-                return True
+                ):
+                    return True
+            else:
+                # Check if we have a hit
+                if (
+                    name_ver[0] == vendor
+                    and name_ver[1] == package
+                    and version_compare(
+                        name_ver[2],
+                        min_affected_version_including,
+                        max_affected_version_including,
+                        min_affected_version_excluding,
+                        max_affected_version_excluding,
+                    )
+                ):
+                    return True
         # Search by pos, vendor, name and version
         if len(name_ver) == 4:
             # Check if we have a hit

--- a/vdb/lib/osv.py
+++ b/vdb/lib/osv.py
@@ -31,7 +31,12 @@ except ImportError:
 
 json_lib = orjson if ORJSON_AVAILABLE else json
 
-vendor_overrides = {"apk": "alpine", "deb": "debian", "go": "golang"}
+vendor_overrides = {
+    "apk": "alpine",
+    "deb": "debian",
+    "go": "golang",
+    "crates.io": "crates",
+}
 
 
 class OSVSource(NvdSource):
@@ -183,7 +188,8 @@ class OSVSource(NvdSource):
                     vectorString = dvectorString
                 exploitabilityScore = score
             ranges = pkg_data.get("ranges", [])
-            vendor = pkg_data.get("package", {}).get("ecosystem", "").lower()
+            vendor_ecosystem = pkg_data.get("package", {}).get("ecosystem", "").lower()
+            vendor = vendor_ecosystem
             pkg_name = pkg_data.get("package", {}).get("name", "")
             pkg_name_list = []
             purl = parse_purl(pkg_data.get("package", {}).get("purl", ""))
@@ -200,8 +206,8 @@ class OSVSource(NvdSource):
             pkg_name_list.append(pkg_name)
             # For OS packages, such as alpine OSV appends the os version to the vendor
             # Let's remove it and add it to package name
-            if ":" in vendor and ("alpine" in vendor or "debian" in vendor):
-                tmpV = vendor.split(":")
+            if ":" in vendor_ecosystem and ("alpine" in vendor or "debian" in vendor):
+                tmpV = vendor_ecosystem.split(":")
                 vendor = tmpV[0].lower()
                 vdistro = tmpV[1]
                 if vendor == "alpine":

--- a/vdb/lib/storage.py
+++ b/vdb/lib/storage.py
@@ -81,7 +81,7 @@ def stream_bulk_search(match_list, key_func, db_file=config.vdb_bin_file):
     with open(db_file, mode="rb") as fp:
         for amatch in match_list:
             tmpA = amatch.split("|")
-            if len(tmpA) == 4:
+            if len(tmpA) >= 3:
                 tmpB = tmpA[0].split("_")
                 store_pos = tmpB[0]
                 store_end_pos = None

--- a/vdb/lib/utils.py
+++ b/vdb/lib/utils.py
@@ -484,13 +484,7 @@ def version_compare(
         # Easy check
         if compare_ver and mae and compare_ver == mae:
             return False
-        (
-            tcompare_ver,
-            tmin_version,
-            tmax_version,
-            tmie,
-            tmae,
-        ) = trim_epoch(
+        (tcompare_ver, tmin_version, tmax_version, tmie, tmae,) = trim_epoch(
             compare_ver,
             min_version,
             max_version,


### PR DESCRIPTION
At some point, cdxgen has stopped generating precise sbom for container images with distro and distro_name qualifiers. This had broken the functionality for container image search for many distros including ubuntu. This PR relaxes by supporting vendor less searches. At the same time, cdxgen is getting fixed to add distro and distro_name qualifiers by parsing os-release info.