### PR TITLE
Improved version parsing for suse. 

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "5.2.1"
+version = "5.2.2"
 description = "AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/test/data/SUSE-SU-2015-0439-1.json
+++ b/test/data/SUSE-SU-2015-0439-1.json
@@ -1,0 +1,2219 @@
+{
+  "Title": "Security update for glibc",
+  "Tracking": {
+    "ID": "SUSE-SU-2015:0439-1",
+    "Status": "Final",
+    "Version": "1",
+    "InitialReleaseDate": "2014-08-29T01:15:58Z",
+    "CurrentReleaseDate": "2014-08-29T01:15:58Z",
+    "RevisionHistory": [
+      {
+        "Number": "1",
+        "Date": "2014-08-29T01:15:58Z",
+        "Description": "current"
+      }
+    ]
+  },
+  "Notes": [
+    {
+      "Text": "Security update for glibc",
+      "Title": "Topic",
+      "Type": "Summary"
+    },
+    {
+      "Text": "\nThis glibc update fixes a critical privilege escalation problem and two \nnon-security issues:\n\n    * bnc#892073: An off-by-one error leading to a heap-based buffer\n      overflow was found in __gconv_translit_find(). An exploit that\n      targets the problem is publicly available. (CVE-2014-5119)\n    * bnc#892065: setenv-alloca.patch: Avoid unbound alloca in setenv.\n    * bnc#888347: printf-multibyte-format.patch: Don't parse %s format\n      argument as multi-byte string.\n\nSecurity Issues:\n\n    * CVE-2014-5119\n      \u003chttp://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2014-5119\u003e\n\n",
+      "Title": "Details",
+      "Type": "General"
+    },
+    {
+      "Text": "The CVRF data is provided by SUSE under the Creative Commons License 4.0 with Attribution (CC-BY-4.0).",
+      "Title": "Terms of Use",
+      "Type": "Legal Disclaimer"
+    },
+    {
+      "Text": "sdksp3-glibc,sledsp3-glibc,slessp3-glibc",
+      "Title": "Patchnames",
+      "Type": "Details"
+    }
+  ],
+  "ProductTree": {
+    "Relationships": [
+      {
+        "ProductReference": "glibc-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-i18ndata-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "nscd-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Desktop 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-html-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-i18ndata-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-info-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "nscd-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-html-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-i18ndata-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-info-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "nscd-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server 11 SP3-TERADATA",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-devel-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-html-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-i18ndata-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-info-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-locale-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-32bit-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-profile-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-x86-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "nscd-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Server for SAP Applications 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-html-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Software Development Kit 11 SP3",
+        "RelationType": "Default Component Of"
+      },
+      {
+        "ProductReference": "glibc-info-2.11.3-17.72.14",
+        "RelatesToProductReference": "SUSE Linux Enterprise Software Development Kit 11 SP3",
+        "RelationType": "Default Component Of"
+      }
+    ]
+  },
+  "References": [
+    {
+      "URL": "https://www.suse.com/support/update/announcement/2015/suse-su-20150439-1/",
+      "Description": "Link for SUSE-SU-2015:0439-1"
+    },
+    {
+      "URL": "https://lists.suse.com/pipermail/sle-security-updates/2015-March/001271.html",
+      "Description": "E-Mail link for SUSE-SU-2015:0439-1"
+    },
+    {
+      "URL": "https://www.suse.com/support/security/rating/",
+      "Description": "SUSE Security Ratings"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/691365",
+      "Description": "SUSE Bug 691365"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/779320",
+      "Description": "SUSE Bug 779320"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/791928",
+      "Description": "SUSE Bug 791928"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/801246",
+      "Description": "SUSE Bug 801246"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/811979",
+      "Description": "SUSE Bug 811979"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/813121",
+      "Description": "SUSE Bug 813121"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/819347",
+      "Description": "SUSE Bug 819347"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/822210",
+      "Description": "SUSE Bug 822210"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/827811",
+      "Description": "SUSE Bug 827811"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/828235",
+      "Description": "SUSE Bug 828235"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/828637",
+      "Description": "SUSE Bug 828637"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/830268",
+      "Description": "SUSE Bug 830268"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/834594",
+      "Description": "SUSE Bug 834594"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/836746",
+      "Description": "SUSE Bug 836746"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/839870",
+      "Description": "SUSE Bug 839870"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/844309",
+      "Description": "SUSE Bug 844309"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/847227",
+      "Description": "SUSE Bug 847227"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/854445",
+      "Description": "SUSE Bug 854445"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/863499",
+      "Description": "SUSE Bug 863499"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/864081",
+      "Description": "SUSE Bug 864081"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/872832",
+      "Description": "SUSE Bug 872832"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/882028",
+      "Description": "SUSE Bug 882028"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/882600",
+      "Description": "SUSE Bug 882600"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/883217",
+      "Description": "SUSE Bug 883217"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/886416",
+      "Description": "SUSE Bug 886416"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/887022",
+      "Description": "SUSE Bug 887022"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/888347",
+      "Description": "SUSE Bug 888347"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/891843",
+      "Description": "SUSE Bug 891843"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/892065",
+      "Description": "SUSE Bug 892065"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/892073",
+      "Description": "SUSE Bug 892073"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/894553",
+      "Description": "SUSE Bug 894553"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/894556",
+      "Description": "SUSE Bug 894556"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/903288",
+      "Description": "SUSE Bug 903288"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/904461",
+      "Description": "SUSE Bug 904461"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/906371",
+      "Description": "SUSE Bug 906371"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/909053",
+      "Description": "SUSE Bug 909053"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/913646",
+      "Description": "SUSE Bug 913646"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/915526",
+      "Description": "SUSE Bug 915526"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/916222",
+      "Description": "SUSE Bug 916222"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/917072",
+      "Description": "SUSE Bug 917072"
+    },
+    {
+      "URL": "https://bugzilla.suse.com/919678",
+      "Description": "SUSE Bug 919678"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2012-4412/",
+      "Description": "SUSE CVE CVE-2012-4412 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2012-6656/",
+      "Description": "SUSE CVE CVE-2012-6656 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-0242/",
+      "Description": "SUSE CVE CVE-2013-0242 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-1914/",
+      "Description": "SUSE CVE CVE-2013-1914 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-4237/",
+      "Description": "SUSE CVE CVE-2013-4237 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-4332/",
+      "Description": "SUSE CVE CVE-2013-4332 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-4357/",
+      "Description": "SUSE CVE CVE-2013-4357 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-4458/",
+      "Description": "SUSE CVE CVE-2013-4458 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-4788/",
+      "Description": "SUSE CVE CVE-2013-4788 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2013-7423/",
+      "Description": "SUSE CVE CVE-2013-7423 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-0475/",
+      "Description": "SUSE CVE CVE-2014-0475 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-4043/",
+      "Description": "SUSE CVE CVE-2014-4043 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-5119/",
+      "Description": "SUSE CVE CVE-2014-5119 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-6040/",
+      "Description": "SUSE CVE CVE-2014-6040 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-7817/",
+      "Description": "SUSE CVE CVE-2014-7817 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2014-9402/",
+      "Description": "SUSE CVE CVE-2014-9402 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2015-0235/",
+      "Description": "SUSE CVE CVE-2015-0235 page"
+    },
+    {
+      "URL": "https://www.suse.com/security/cve/CVE-2015-1472/",
+      "Description": "SUSE CVE CVE-2015-1472 page"
+    }
+  ],
+  "Vulnerabilities": [
+    {
+      "CVE": "CVE-2012-4412",
+      "Description": "Integer overflow in string/strcoll_l.c in the GNU C Library (aka glibc or libc6) 2.17 and earlier allows context-dependent attackers to cause a denial of service (crash) or possibly execute arbitrary code via a long string, which triggers a heap-based buffer overflow.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "important"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2012-4412.html",
+          "Description": "CVE-2012-4412"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/779320",
+          "Description": "SUSE Bug 779320"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/848783",
+          "Description": "SUSE Bug 848783"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/882910",
+          "Description": "SUSE Bug 882910"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/920169",
+          "Description": "SUSE Bug 920169"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/920338",
+          "Description": "SUSE Bug 920338"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2012-6656",
+      "Description": "iconvdata/ibm930.c in GNU C Library (aka glibc) before 2.16 allows context-dependent attackers to cause a denial of service (out-of-bounds read) via a multibyte character value of \"0xffff\" to the iconv function when converting IBM930 encoded data to UTF-8.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2012-6656.html",
+          "Description": "CVE-2012-6656"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/894556",
+          "Description": "SUSE Bug 894556"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/903057",
+          "Description": "SUSE Bug 903057"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-0242",
+      "Description": "Buffer overflow in the extend_buffers function in the regular expression matcher (posix/regexec.c) in glibc, possibly 2.17 and earlier, allows context-dependent attackers to cause a denial of service (memory corruption and crash) via crafted multibyte characters.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-0242.html",
+          "Description": "CVE-2013-0242"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/801246",
+          "Description": "SUSE Bug 801246"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/848783",
+          "Description": "SUSE Bug 848783"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/882910",
+          "Description": "SUSE Bug 882910"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-1914",
+      "Description": "Stack-based buffer overflow in the getaddrinfo function in sysdeps/posix/getaddrinfo.c in GNU C Library (aka glibc or libc6) 2.17 and earlier allows remote attackers to cause a denial of service (crash) via a (1) hostname or (2) IP address that triggers a large number of domain conversion results.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-1914.html",
+          "Description": "CVE-2013-1914"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/813121",
+          "Description": "SUSE Bug 813121"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/826666",
+          "Description": "SUSE Bug 826666"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/882910",
+          "Description": "SUSE Bug 882910"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/941444",
+          "Description": "SUSE Bug 941444"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-4237",
+      "Description": "sysdeps/posix/readdir_r.c in the GNU C Library (aka glibc or libc6) 2.18 and earlier allows context-dependent attackers to cause a denial of service (out-of-bounds write and crash) or possibly execute arbitrary code via a crafted (1) NTFS or (2) CIFS image.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-4237.html",
+          "Description": "CVE-2013-4237"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/834594",
+          "Description": "SUSE Bug 834594"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/882910",
+          "Description": "SUSE Bug 882910"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/883022",
+          "Description": "SUSE Bug 883022"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-4332",
+      "Description": "Multiple integer overflows in malloc/malloc.c in the GNU C Library (aka glibc or libc6) 2.18 and earlier allow context-dependent attackers to cause a denial of service (heap corruption) via a large value to the (1) pvalloc, (2) valloc, (3) posix_memalign, (4) memalign, or (5) aligned_alloc functions.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-4332.html",
+          "Description": "CVE-2013-4332"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/1123874",
+          "Description": "SUSE Bug 1123874"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/839870",
+          "Description": "SUSE Bug 839870"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/882910",
+          "Description": "SUSE Bug 882910"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-4357",
+      "Description": "The eglibc package before 2.14 incorrectly handled the getaddrinfo() function. An attacker could use this issue to cause a denial of service.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "important"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-4357.html",
+          "Description": "CVE-2013-4357"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/844309",
+          "Description": "SUSE Bug 844309"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/883217",
+          "Description": "SUSE Bug 883217"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/903057",
+          "Description": "SUSE Bug 903057"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-4458",
+      "Description": "Stack-based buffer overflow in the getaddrinfo function in sysdeps/posix/getaddrinfo.c in GNU C Library (aka glibc or libc6) 2.18 and earlier allows remote attackers to cause a denial of service (crash) via a (1) hostname or (2) IP address that triggers a large number of AF_INET6 address results. NOTE: this vulnerability exists because of an incomplete fix for CVE-2013-1914.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-4458.html",
+          "Description": "CVE-2013-4458"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/1123874",
+          "Description": "SUSE Bug 1123874"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/847227",
+          "Description": "SUSE Bug 847227"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/883217",
+          "Description": "SUSE Bug 883217"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/941444",
+          "Description": "SUSE Bug 941444"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/955181",
+          "Description": "SUSE Bug 955181"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/967023",
+          "Description": "SUSE Bug 967023"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/980483",
+          "Description": "SUSE Bug 980483"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-4788",
+      "Description": "The PTR_MANGLE implementation in the GNU C Library (aka glibc or libc6) 2.4, 2.17, and earlier, and Embedded GLIBC (EGLIBC) does not initialize the random value for the pointer guard, which makes it easier for context-dependent attackers to control execution flow by leveraging a buffer-overflow vulnerability in an application and using the known zero value pointer guard to calculate a pointer address.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-4788.html",
+          "Description": "CVE-2013-4788"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/1123874",
+          "Description": "SUSE Bug 1123874"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/830268",
+          "Description": "SUSE Bug 830268"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/882910",
+          "Description": "SUSE Bug 882910"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/950944",
+          "Description": "SUSE Bug 950944"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2013-7423",
+      "Description": "The send_dg function in resolv/res_send.c in GNU C Library (aka glibc or libc6) before 2.20 does not properly reuse file descriptors, which allows remote attackers to send DNS queries to unintended locations via a large number of requests that trigger a call to the getaddrinfo function.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2013-7423.html",
+          "Description": "CVE-2013-7423"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/1123874",
+          "Description": "SUSE Bug 1123874"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/915526",
+          "Description": "SUSE Bug 915526"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {
+        "BaseScore": "2.6",
+        "Vector": "AV:L/AC:H/Au:N/C:P/I:N/A:P"
+      }
+    },
+    {
+      "CVE": "CVE-2014-0475",
+      "Description": "Multiple directory traversal vulnerabilities in GNU C Library (aka glibc or libc6) before 2.20 allow context-dependent attackers to bypass ForceCommand restrictions and possibly have other unspecified impact via a .. (dot dot) in a (1) LC_*, (2) LANG, or other locale environment variable.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-0475.html",
+          "Description": "CVE-2014-0475"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/887022",
+          "Description": "SUSE Bug 887022"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/896776",
+          "Description": "SUSE Bug 896776"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/916222",
+          "Description": "SUSE Bug 916222"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2014-4043",
+      "Description": "The posix_spawn_file_actions_addopen function in glibc before 2.20 does not copy its path argument in accordance with the POSIX specification, which allows context-dependent attackers to trigger use-after-free vulnerabilities.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "important"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-4043.html",
+          "Description": "CVE-2014-4043"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/882600",
+          "Description": "SUSE Bug 882600"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/939797",
+          "Description": "SUSE Bug 939797"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2014-5119",
+      "Description": "Off-by-one error in the __gconv_translit_find function in gconv_trans.c in GNU C Library (aka glibc) allows context-dependent attackers to cause a denial of service (crash) or execute arbitrary code via vectors related to the CHARSET environment variable and gconv transliteration modules.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "important"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-5119.html",
+          "Description": "CVE-2014-5119"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/892073",
+          "Description": "SUSE Bug 892073"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/903057",
+          "Description": "SUSE Bug 903057"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/916222",
+          "Description": "SUSE Bug 916222"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2014-6040",
+      "Description": "GNU C Library (aka glibc) before 2.20 allows context-dependent attackers to cause a denial of service (out-of-bounds read and crash) via a multibyte character value of \"0xffff\" to the iconv function when converting (1) IBM933, (2) IBM935, (3) IBM937, (4) IBM939, or (5) IBM1364 encoded data to UTF-8.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-6040.html",
+          "Description": "CVE-2014-6040"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/894553",
+          "Description": "SUSE Bug 894553"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/903057",
+          "Description": "SUSE Bug 903057"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/916222",
+          "Description": "SUSE Bug 916222"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2014-7817",
+      "Description": "The wordexp function in GNU C Library (aka glibc) 2.21 does not enforce the WRDE_NOCMD flag, which allows context-dependent attackers to execute arbitrary commands, as demonstrated by input containing \"$((`...`))\".",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-7817.html",
+          "Description": "CVE-2014-7817"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/906371",
+          "Description": "SUSE Bug 906371"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2014-9402",
+      "Description": "The nss_dns implementation of getnetbyname in GNU C Library (aka glibc) before 2.21, when the DNS backend in the Name Service Switch configuration is enabled, allows remote attackers to cause a denial of service (infinite loop) by sending a positive answer while a network name is being process.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "important"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2014-9402.html",
+          "Description": "CVE-2014-9402"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/910599",
+          "Description": "SUSE Bug 910599"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2015-0235",
+      "Description": "Heap-based buffer overflow in the __nss_hostname_digits_dots function in glibc 2.2, and other 2.x versions before 2.18, allows context-dependent attackers to execute arbitrary code via vectors related to the (1) gethostbyname or (2) gethostbyname2 function, aka \"GHOST.\"",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "critical"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2015-0235.html",
+          "Description": "CVE-2015-0235"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/844309",
+          "Description": "SUSE Bug 844309"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/913646",
+          "Description": "SUSE Bug 913646"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/949238",
+          "Description": "SUSE Bug 949238"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/954983",
+          "Description": "SUSE Bug 954983"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    },
+    {
+      "CVE": "CVE-2015-1472",
+      "Description": "The ADDW macro in stdio-common/vfscanf.c in the GNU C Library (aka glibc or libc6) before 2.21 does not properly consider data-type size during memory allocation, which allows context-dependent attackers to cause a denial of service (buffer overflow) or possibly have unspecified other impact via a long line containing wide characters that are improperly handled in a wscanf call.",
+      "Threats": [
+        {
+          "Type": "Impact",
+          "Severity": "moderate"
+        }
+      ],
+      "References": [
+        {
+          "URL": "https://www.suse.com/security/cve/CVE-2015-1472.html",
+          "Description": "CVE-2015-1472"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/916222",
+          "Description": "SUSE Bug 916222"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/920341",
+          "Description": "SUSE Bug 920341"
+        },
+        {
+          "URL": "https://bugzilla.suse.com/922243",
+          "Description": "SUSE Bug 922243"
+        }
+      ],
+      "ProductStatuses": [
+        {
+          "Type": "Fixed",
+          "ProductID": [
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Desktop 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3-TERADATA:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-devel-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-i18ndata-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-info-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-locale-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-32bit-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-profile-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:glibc-x86-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Server for SAP Applications 11 SP3:nscd-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-html-2.11.3-17.72.14",
+            "SUSE Linux Enterprise Software Development Kit 11 SP3:glibc-info-2.11.3-17.72.14"
+          ]
+        }
+      ],
+      "CVSSScoreSets": {}
+    }
+  ]
+}

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -192,6 +192,15 @@ def test_aqua_suse_json():
 
 
 @pytest.fixture
+def test_aqua_suse_json1():
+    test_cve_data = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "data", "SUSE-SU-2015-0439-1.json"
+    )
+    with open(test_cve_data, "r") as fp:
+        return json.loads(fp.read())
+
+
+@pytest.fixture
 def test_aqua_photon_json():
     test_cve_data = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "data", "CVE-2021-3618.json"
@@ -397,6 +406,7 @@ def test_aqua_convert(
     test_aqua_arch_json,
     test_aqua_opensuse_json,
     test_aqua_suse_json,
+    test_aqua_suse_json1,
     test_aqua_photon_json,
     test_aqua_debian_json,
     test_aqua_debian2_json,
@@ -432,6 +442,8 @@ def test_aqua_convert(
     cve_data = aqualatest.convert(test_aqua_opensuse_json)
     assert cve_data
     cve_data = aqualatest.convert(test_aqua_suse_json)
+    assert cve_data
+    cve_data = aqualatest.convert(test_aqua_suse_json1)
     assert cve_data
     cve_data = aqualatest.convert(test_aqua_photon_json)
     assert cve_data

--- a/vdb/lib/aqua.py
+++ b/vdb/lib/aqua.py
@@ -177,7 +177,7 @@ class AquaSource(NvdSource):
         severity = threat_to_severity[cve_data.get("severity").lower()]
         score, severity, vectorString, attackComplexity = get_default_cve_data(severity)
         exploitabilityScore = score
-        vendor = "alma"
+        vendor = "almalinux"
         pkg_name = packages[0].get("name")
         version_start_including = ""
         version_end_including = ""
@@ -596,6 +596,17 @@ class AquaSource(NvdSource):
                     pass
         return ret_data
 
+    def product_ref_to_name_version(self, product_ref):
+        product_parts = product_ref.split("-")
+        name_parts = []
+        version_parts = []
+        for i, part in enumerate(product_parts):
+            if part[0].isdigit() and "bit" not in part:
+                version_parts = product_parts[i:]
+                name_parts = product_parts[:i]
+                break
+        return "-".join(name_parts), "-".join(version_parts)
+
     def suse_to_vuln(self, cve_data):
         """Suse Linux"""
         ret_data = []
@@ -606,7 +617,6 @@ class AquaSource(NvdSource):
         description = ""
         severity = ""
         # Package name has to be extracted from the title :(
-        pkg_name = cve_data.get("Title", "").split(" ")[-1]
         publishedDate = cve_data.get("Tracking", {}).get("InitialReleaseDate", "")
         lastModifiedDate = cve_data.get("Tracking", {}).get("CurrentReleaseDate", "")
         if cve_data.get("Vulnerabilities"):
@@ -635,7 +645,7 @@ class AquaSource(NvdSource):
                     pkg_key = pref.get("ProductReference")
                     if done_pkgs.get(pkg_key):
                         continue
-                    version = pkg_key.replace(pkg_name + "-", "")
+                    pkg_name, version = self.product_ref_to_name_version(pkg_key)
                     version_start_including = ""
                     version_end_including = ""
                     version_start_excluding = ""

--- a/vdb/lib/config.py
+++ b/vdb/lib/config.py
@@ -62,6 +62,8 @@ osv_url_dict = {
     "debian": "https://osv-vulnerabilities.storage.googleapis.com/Debian/all.zip",
     "oss-fuzz": "https://osv-vulnerabilities.storage.googleapis.com/OSS-Fuzz/all.zip",
     "cran": "https://osv-vulnerabilities.storage.googleapis.com/CRAN/all.zip",
+    "almalinux": "https://osv-vulnerabilities.storage.googleapis.com/AlmaLinux/all.zip",
+    "rockylinux": "https://osv-vulnerabilities.storage.googleapis.com/Rocky%20Linux/all.zip",
 }
 
 aquasec_vuln_list_url = (

--- a/vdb/lib/osv.py
+++ b/vdb/lib/osv.py
@@ -206,15 +206,28 @@ class OSVSource(NvdSource):
             pkg_name_list.append(pkg_name)
             # For OS packages, such as alpine OSV appends the os version to the vendor
             # Let's remove it and add it to package name
-            if ":" in vendor_ecosystem and ("alpine" in vendor or "debian" in vendor):
+            if ":" in vendor_ecosystem and (
+                "alpine" in vendor
+                or "debian" in vendor
+                or "almalinux" in vendor
+                or "rocky" in vendor
+            ):
                 tmpV = vendor_ecosystem.split(":")
-                vendor = tmpV[0].lower()
+                vendor = tmpV[0].lower().replace(" ", "").replace("-", "")
                 vdistro = tmpV[1]
                 if vendor == "alpine":
                     vdistro = vdistro.replace("v", "")
+                # In os-release, ID for rockylinux is simply rocky
+                if "rocky" in vendor:
+                    vendor = vendor.replace("linux", "")
                 edition = f"{vendor}-{vdistro}"
-                # Only use the precise version for debian and alpine
-                if "debian" in vendor or "alpine" in vendor:
+                # Only use the precise version for os packages
+                if (
+                    "debian" in vendor
+                    or "alpine" in vendor
+                    or "almalinux" in vendor
+                    or "rocky" in vendor
+                ):
                     pkg_name_list = [f"{edition}/{pkg_name}"]
                 else:
                     pkg_name_list.append(f"{edition}/{pkg_name}")


### PR DESCRIPTION
Fixes #63

We live in a world where distros (even with the word enterprise in the name) do not provide vulnerability information using purl. This makes identifying the package name and version difficult since even versions could have hyphens, alphabets, and colons.