### PR TITLE
Better logic to handle osv versions list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "5.4.2"
+version = "5.4.3"
 description = "AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -407,7 +407,7 @@ def test_osv_convert(
     assert cve_data
     cve_data = osvlatest.convert(test_osv_mvn_json)
     assert cve_data
-    assert len(cve_data) == 4
+    assert len(cve_data) == 3
     cve_data = osvlatest.convert(test_osv_mixed_json)
     assert cve_data
     assert len(cve_data) == 3

--- a/vdb/lib/osv.py
+++ b/vdb/lib/osv.py
@@ -6,6 +6,7 @@ This module fetches the vulnerability data from osv.dev and stores them in NVD C
 from zipfile import ZipFile
 
 import httpx
+from semver import Version
 
 from vdb.lib import CustomNamedTemporaryFile, config
 from vdb.lib.nvd import NvdSource
@@ -235,8 +236,25 @@ class OSVSource(NvdSource):
             # Substitute alpine for apk and debian for deb
             if vendor_overrides.get(vendor):
                 vendor = vendor_overrides.get(vendor)
-            # Are there any precise list of versions?
-            if len(versions_list) > 1:
+            # For some ecosystem, osv provides a full list of versions with partial events. See osv-pypi2.json for an example
+            # Problem 1: Storing each version as-is is slowing down vdb
+            # Problem 2: The versions_list may be unsorted and trying to sort based on semantic versions can fail
+            # Solution: We do our best to sort the versions_list. If it fails, we assume the input is sorted and store the first and last entry as min and max.
+            # The assumption seems to be working as of today, but could result in false positives or false negatives in the future.
+            needs_version_backup = True
+            for r in ranges:
+                events = r.get("events")
+                for ev in events:
+                    if ev.get("fixed") or ev.get("last_affected"):
+                        needs_version_backup = False
+                        break
+            if needs_version_backup and len(versions_list) > 1:
+                try:
+                    min_ver = min(versions_list, key=Version.parse)
+                    max_ver = max(versions_list, key=Version.parse)
+                except Exception:
+                    min_ver = versions_list[0]
+                    max_ver = versions_list[-1]
                 for full_pkg in pkg_name_list:
                     tdata = config.CVE_TPL % dict(
                         cve_id=cve_id,
@@ -249,13 +267,13 @@ class OSVSource(NvdSource):
                         product=full_pkg,
                         version="*",
                         edition=edition,
-                        version_start_including=versions_list[0],
-                        version_end_including=versions_list[-1],
+                        version_start_including=min_ver,
+                        version_end_including=max_ver,
                         version_start_excluding="",
                         version_end_excluding="",
                         fix_version_start_including="",
                         fix_version_end_including="",
-                        fix_version_start_excluding="",
+                        fix_version_start_excluding=max_ver,
                         fix_version_end_excluding="",
                         severity=severity,
                         attackComplexity=attackComplexity,

--- a/vdb/lib/utils.py
+++ b/vdb/lib/utils.py
@@ -881,10 +881,20 @@ def convert_to_occurrence(datas):
             package_type = vdetails["package_type"]
             package = vdetails["package"]
             cpe_uri = vdetails["cpe_uri"]
+            fixed_location = vdetails["fixed_location"]
+            mii = vdetails["mii"]
+            mai = vdetails["mai"]
+            mie = vdetails["mie"]
+            mae = vdetails["mae"]
         else:
             package_type = vdetails.package_type
             package = vdetails.package
             cpe_uri = vdetails.cpe_uri
+            fixed_location = vdetails.fixed_location
+            mii = vdetails.mii
+            mai = vdetails.mai
+            mie = vdetails.mie
+            mae = vdetails.mae
         unique_key = vobj["id"] + "|" + match if match else vobj["id"]
         # Filter duplicates for the same package with the same id
         if unique_key not in id_list:
@@ -896,11 +906,11 @@ def convert_to_occurrence(datas):
                 cvss_score=vobj["score"],
                 package_issue=PackageIssue(
                     affected_location=cpe_uri,
-                    fixed_location=vdetails.fixed_location,
-                    mii=vdetails.mii,
-                    mai=vdetails.mai,
-                    mie=vdetails.mie,
-                    mae=vdetails.mae,
+                    fixed_location=fixed_location,
+                    mii=mii,
+                    mai=mai,
+                    mie=mie,
+                    mae=mae,
                 ),
                 short_description=vobj["description"],
                 long_description=None,


### PR DESCRIPTION
The best way to understand this PR is to try this search on the master and with this branch.

```
vdb --search "pkg:maven/org.springframework/spring-core@5.2.5?type=jar"
```

The fix version would be missing in the master since we do know or store the fix version correctly while dealing with the versions array.