### PR TITLE
Fix/issue 75 version_compare

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "5.5.3"
+version = "5.5.4"
 description = "AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -17,6 +17,8 @@ def test_normalise():
 def test_version_compare():
     res = utils.version_compare("2.0.0", "2.0.0", "3.0.0", "2.0.0", "3.0.0")
     assert not res
+    res = utils.version_compare("3.0.0", "2.0.0", "3.0.0", "2.0.0", "3.0.0")
+    assert not res
     res = utils.version_compare("3.0.0", "2.0.0", "2.7.9.4")
     assert not res
     res = utils.version_compare("2.0.0", "2.0.0", "2.7.9.4")
@@ -131,11 +133,6 @@ def test_version_compare():
     assert not res
     res = utils.version_compare("12.1.0.2.0", "*", "12.1.0.2", None, None)
     assert res
-
-
-def test_version_compare1():
-    res = utils.version_compare("2.0.0", None, "3.0.0", "2.0.0", "3.0.0")
-    assert not res
 
 
 def test_version_compare_go():

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -15,6 +15,8 @@ def test_normalise():
 
 
 def test_version_compare():
+    res = utils.version_compare("2.0.0", "2.0.0", "3.0.0", "2.0.0", "3.0.0")
+    assert not res
     res = utils.version_compare("3.0.0", "2.0.0", "2.7.9.4")
     assert not res
     res = utils.version_compare("2.0.0", "2.0.0", "2.7.9.4")
@@ -127,11 +129,13 @@ def test_version_compare():
     assert res
     res = utils.version_compare("1.0.3", "1.4.1", "*", None, None)
     assert not res
+    res = utils.version_compare("12.1.0.2.0", "*", "12.1.0.2", None, None)
+    assert res
 
 
 def test_version_compare1():
-    res = utils.version_compare("12.1.0.2.0", "*", "12.1.0.2", None, None)
-    assert res
+    res = utils.version_compare("2.0.0", None, "3.0.0", "2.0.0", "3.0.0")
+    assert not res
 
 
 def test_version_compare_go():

--- a/vdb/lib/utils.py
+++ b/vdb/lib/utils.py
@@ -600,10 +600,10 @@ def version_compare(
     # Semver compatible and including versions provided
     is_min_exclude = False
     is_max_exclude = False
-    if (not min_version or min_version == "*") and mie:
+    if mie:
         min_version = mie
         is_min_exclude = True
-    if (not max_version or max_version == "*") and mae:
+    if mae:
         max_version = mae
         is_max_exclude = True
     if not min_version:


### PR DESCRIPTION
Closes #75 

Changes logic for version_compare in utils to use the mie and mae when they are provided, even if min or max versions are also included. Adds additional tests to demonstrate why this is necessary.