### PR TITLE
Prefer CVE alias over others

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "5.6.0"
+version = "5.6.1"
 description = "AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/vdb/lib/osv.py
+++ b/vdb/lib/osv.py
@@ -124,7 +124,7 @@ class OSVSource(NvdSource):
         # Try to locate the CVE id from the aliases section
         if not cve_id.startswith("CVE") and not cve_id.startswith("RUSTSEC"):
             for i in aliases:
-                if not i.startswith("OSV"):
+                if i.startswith("CVE"):
                     cve_id = i
                     break
         assigner = "OSV"


### PR DESCRIPTION
Where there are multiple aliases, we now prefer the CVE alias over others.

```
"aliases": [
    "BIT-dotnet-2024-0056",
    "BIT-dotnet-sdk-2024-0056",
    "CVE-2024-0056"
  ],
```
