### PR TITLE
npm use cvss attribute if present to extract the score

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "5.6.1"
+version = "5.6.2"
 description = "AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/vdb/lib/npm.py
+++ b/vdb/lib/npm.py
@@ -3,6 +3,7 @@ NPM Security Advisory to NVD CVE converter
 
 This module implements basic functionality to query npm registry for security advisories
 """
+
 import logging
 
 try:
@@ -206,6 +207,10 @@ class NpmSource(NvdSource):
             score, severity, vectorString, attackComplexity = get_default_cve_data(
                 severity
             )
+            cvss = v.get("cvss")
+            if cvss:
+                score = cvss.get("score")
+                vectorString = cvss.get("vectorString")
             exploitabilityScore = score
             metadata = v.get("metadata", {})
             if isinstance(metadata, dict) and metadata.get("exploitability"):


### PR DESCRIPTION
With this fix, we get the correct cvss score returned for certain packages instead of the default 5.0.

```
python depscan/cli.py --purl "pkg:npm/axios@1.5.1" --reports-dir /tmp/reports
```

```
Dependency Scan Results (NPM)
╔══════════════════════════════════════════════════════════════╤═════════════════════╤═══════════════════════════╤════════════════════╤══════════════╗
║ CVE                                                          │ Insights            │ Fix Version               │ Severity           │        Score ║
╟──────────────────────────────────────────────────────────────┼─────────────────────┼───────────────────────────┼────────────────────┼──────────────╢
║ axios@1.5.1 ⬅ CVE-2023-45857                                 │                     │ 1.6.0                     │ MEDIUM             │          6.5 ║
╚══════════════════════════════════════════════════════════════╧═════════════════════╧═══════════════════════════╧════════════════════╧══════════════╝
```

```
python depscan/cli.py --purl "pkg:npm/follow-redirects@1.15.2" --reports-dir /tmp/reports
```

```
Dependency Scan Results (NPM)
╔══════════════════════════════════════════════════════════════════════════╤══════════════════╤═══════════════════════╤══════════════════╤═══════════╗
║ CVE                                                                      │ Insights         │ Fix Version           │ Severity         │     Score ║
╟──────────────────────────────────────────────────────────────────────────┼──────────────────┼───────────────────────┼──────────────────┼───────────╢
║ follow-redirects@1.15.2 ⬅ CVE-2023-26159                                 │                  │ 1.15.4                │ MEDIUM           │       6.1 ║
╚══════════════════════════════════════════════════════════════════════════╧══════════════════╧═══════════════════════╧══════════════════╧═══════════╝
```
