### PR TITLE
Handle zero scores from npm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "5.6.2"
+version = "5.6.3"
 description = "AppThreat's vulnerability database and package search library with a built-in file based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/vdb/lib/npm.py
+++ b/vdb/lib/npm.py
@@ -209,8 +209,10 @@ class NpmSource(NvdSource):
             )
             cvss = v.get("cvss")
             if cvss:
-                score = cvss.get("score")
-                vectorString = cvss.get("vectorString")
+                if cvss.get("score"):
+                    score = cvss.get("score")
+                if cvss.get("vectorString"):
+                    vectorString = cvss.get("vectorString")
             exploitabilityScore = score
             metadata = v.get("metadata", {})
             if isinstance(metadata, dict) and metadata.get("exploitability"):


### PR DESCRIPTION
Related to https://github.com/owasp-dep-scan/dep-scan/issues/257

By ignoring 0 scores from the `cvss` attribute, a default score gets set based on the severity.