### PR TITLE
nvd api fixed version

### DIFF
--- a/test/data/CVE-2015-3192.json
+++ b/test/data/CVE-2015-3192.json
@@ -1,0 +1,282 @@
+{
+  "id": "CVE-2015-3192",
+  "sourceIdentifier": "secalert@redhat.com",
+  "published": "2016-07-12T19:59:00.240",
+  "lastModified": "2022-04-11T17:18:31.247",
+  "vulnStatus": "Modified",
+  "descriptions": [
+    {
+      "lang": "en",
+      "value": "Pivotal Spring Framework before 3.2.14 and 4.x before 4.1.7 do not properly process inline DTD declarations when DTD is not entirely disabled, which allows remote attackers to cause a denial of service (memory consumption and out-of-memory errors) via a crafted XML file."
+    },
+    {
+      "lang": "es",
+      "value": "Pivotal Spring Framework en versiones anteriores a 3.2.14 y 4.x en versiones anteriores a 4.1.7 no procesa correctamente las declaraciones DTD en línea cuando DTD no está completamente desactivado, lo que permite a atacantes remotos provocar una caída de servicio (consumo de memoria y errores fuera de rango) a través de un archivo XML manipulado."
+    }
+  ],
+  "metrics": {
+    "cvssMetricV30": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "cvssData": {
+          "version": "3.0",
+          "vectorString": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H",
+          "attackVector": "LOCAL",
+          "attackComplexity": "LOW",
+          "privilegesRequired": "NONE",
+          "userInteraction": "REQUIRED",
+          "scope": "UNCHANGED",
+          "confidentialityImpact": "NONE",
+          "integrityImpact": "NONE",
+          "availabilityImpact": "HIGH",
+          "baseScore": 5.5,
+          "baseSeverity": "MEDIUM"
+        },
+        "exploitabilityScore": 1.8,
+        "impactScore": 3.6
+      }
+    ],
+    "cvssMetricV2": [
+      {
+        "source": "nvd@nist.gov",
+        "type": "Primary",
+        "cvssData": {
+          "version": "2.0",
+          "vectorString": "AV:N/AC:M/Au:N/C:N/I:N/A:P",
+          "accessVector": "NETWORK",
+          "accessComplexity": "MEDIUM",
+          "authentication": "NONE",
+          "confidentialityImpact": "NONE",
+          "integrityImpact": "NONE",
+          "availabilityImpact": "PARTIAL",
+          "baseScore": 4.3
+        },
+        "baseSeverity": "MEDIUM",
+        "exploitabilityScore": 8.6,
+        "impactScore": 2.9,
+        "acInsufInfo": false,
+        "obtainAllPrivilege": false,
+        "obtainUserPrivilege": false,
+        "obtainOtherPrivilege": false,
+        "userInteractionRequired": true
+      }
+    ]
+  },
+  "weaknesses": [
+    {
+      "source": "nvd@nist.gov",
+      "type": "Primary",
+      "description": [
+        {
+          "lang": "en",
+          "value": "CWE-119"
+        }
+      ]
+    }
+  ],
+  "configurations": [
+    {
+      "nodes": [
+        {
+          "operator": "OR",
+          "negate": false,
+          "cpeMatch": [
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:pivotal_software:spring_framework:3.2.0:*:*:*:*:*:*:*",
+              "matchCriteriaId": "E02D9007-1215-4FD1-822A-BA95748E75D8"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.1:*:*:*:*:*:*:*",
+              "matchCriteriaId": "D2E2EA60-735E-431E-BEFE-DC5C1046E532"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.2:*:*:*:*:*:*:*",
+              "matchCriteriaId": "DFD1FA92-7BFC-4874-89FC-BE0F378F0DB3"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.3:*:*:*:*:*:*:*",
+              "matchCriteriaId": "7CC0E26F-2E8B-4B30-8C43-8BD2015EBB88"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.4:*:*:*:*:*:*:*",
+              "matchCriteriaId": "3CB73406-5FE4-438E-BCB7-57FBF6EC38D0"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.5:*:*:*:*:*:*:*",
+              "matchCriteriaId": "B76F06BC-F53E-4E37-B84F-3E992D459A49"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.6:*:*:*:*:*:*:*",
+              "matchCriteriaId": "DD8CC0CF-61DE-4E3A-80DD-4AD34EBDF419"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.7:*:*:*:*:*:*:*",
+              "matchCriteriaId": "09D49870-9E17-4049-9ABB-311C319A0E8F"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.8:*:*:*:*:*:*:*",
+              "matchCriteriaId": "EB9CE889-FBC5-4078-ABAC-8BC6CA235D04"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.9:*:*:*:*:*:*:*",
+              "matchCriteriaId": "AF34B57A-9732-44C8-9EC7-07394FB588F8"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.10:*:*:*:*:*:*:*",
+              "matchCriteriaId": "C528FEA9-2E5E-413B-89C1-F14C67059702"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.11:*:*:*:*:*:*:*",
+              "matchCriteriaId": "8C7EA42F-55C6-4934-8F60-98B7717188D2"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.12:*:*:*:*:*:*:*",
+              "matchCriteriaId": "E1DA44C3-D083-4584-8ACC-73B234767669"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:3.2.13:*:*:*:*:*:*:*",
+              "matchCriteriaId": "1D6399F2-B9D6-4097-89DB-5F4B434DFFD3"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodes": [
+        {
+          "operator": "OR",
+          "negate": false,
+          "cpeMatch": [
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:o:fedoraproject:fedora:21:*:*:*:*:*:*:*",
+              "matchCriteriaId": "56BDB5A0-0839-4A20-A003-B8CD56F48171"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:o:fedoraproject:fedora:22:*:*:*:*:*:*:*",
+              "matchCriteriaId": "253C303A-E577-4488-93E6-68A8DD942C38"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "nodes": [
+        {
+          "operator": "OR",
+          "negate": false,
+          "cpeMatch": [
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:pivotal_software:spring_framework:4.1.0:*:*:*:*:*:*:*",
+              "matchCriteriaId": "01D83EE4-F71B-4186-A34E-9128B6DA333B"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:4.1.1:*:*:*:*:*:*:*",
+              "matchCriteriaId": "CC1A4DB1-083B-4AAB-B1A2-CFFD487A1FBF"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:4.1.2:*:*:*:*:*:*:*",
+              "matchCriteriaId": "53D5991E-2CD0-42D9-8158-25FF18275B21"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:4.1.3:*:*:*:*:*:*:*",
+              "matchCriteriaId": "130DBD54-EF87-4A90-A727-F2BFFBF2DFA2"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:4.1.4:*:*:*:*:*:*:*",
+              "matchCriteriaId": "FDB59905-C658-4EFD-B073-FE84F0BF1DDB"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:4.1.5:*:*:*:*:*:*:*",
+              "matchCriteriaId": "B9382948-689D-40CD-ADC8-E41BB1F02D5B"
+            },
+            {
+              "vulnerable": true,
+              "criteria": "cpe:2.3:a:vmware:spring_framework:4.1.6:*:*:*:*:*:*:*",
+              "matchCriteriaId": "2D269ABA-5E23-4F3D-B999-C51B2494EE01"
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "references": [
+    {
+      "url": "http://lists.fedoraproject.org/pipermail/package-announce/2015-July/162015.html",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "http://lists.fedoraproject.org/pipermail/package-announce/2015-July/162017.html",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "http://pivotal.io/security/cve-2015-3192",
+      "source": "secalert@redhat.com",
+      "tags": [
+        "Vendor Advisory"
+      ]
+    },
+    {
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-1592.html",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-1593.html",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-2035.html",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-2036.html",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "http://www.securityfocus.com/bid/90853",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "http://www.securitytracker.com/id/1036587",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "https://access.redhat.com/errata/RHSA-2016:1218",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "https://access.redhat.com/errata/RHSA-2016:1219",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "https://jira.spring.io/browse/SPR-13136",
+      "source": "secalert@redhat.com"
+    },
+    {
+      "url": "https://lists.debian.org/debian-lts-announce/2019/07/msg00012.html",
+      "source": "secalert@redhat.com"
+    }
+  ]
+}

--- a/test/data/osv_multi_events.json
+++ b/test/data/osv_multi_events.json
@@ -1,81 +1,21 @@
 {
-  "schema_version": "1.4.0",
   "id": "GHSA-6v7w-535j-rq5m",
-  "modified": "2024-03-05T18:17:31Z",
-  "published": "2018-10-17T20:29:12Z",
+  "summary": "Pivotal Spring Framework DoS Attack with XML Input",
+  "details": "Pivotal Spring Framework before 3.2.14 and 4.x before 4.1.7 do not properly process inline DTD declarations when DTD is not entirely disabled, which allows remote attackers to cause a denial of service (memory consumption and out-of-memory errors) via a crafted XML file.",
   "aliases": [
     "CVE-2015-3192"
   ],
-  "summary": "Pivotal Spring Framework DoS Attack with XML Input",
-  "details": "Pivotal Spring Framework before 3.2.14 and 4.x before 4.1.7 do not properly process inline DTD declarations when DTD is not entirely disabled, which allows remote attackers to cause a denial of service (memory consumption and out-of-memory errors) via a crafted XML file.",
-  "severity": [
-    {
-      "type": "CVSS_V3",
-      "score": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
-    }
-  ],
-  "affected": [
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-web"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "0"
-            },
-            {
-              "fixed": "3.2.14"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-web"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "4.0.0"
-            },
-            {
-              "fixed": "4.1.7"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "package": {
-        "ecosystem": "Maven",
-        "name": "org.springframework:spring-web"
-      },
-      "ranges": [
-        {
-          "type": "ECOSYSTEM",
-          "events": [
-            {
-              "introduced": "5.0.0.RC2"
-            },
-            {
-              "fixed": "5.0.0.RC3"
-            }
-          ]
-        }
-      ],
-      "versions": [
-        "5.0.0.RC2"
-      ]
-    }
-  ],
+  "modified": "2024-03-05T18:31:10.934674Z",
+  "published": "2018-10-17T20:29:12Z",
+  "database_specific": {
+    "nvd_published_at": "2016-07-12T19:59:00Z",
+    "cwe_ids": [
+      "CWE-119"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2020-06-16T21:20:17Z"
+  },
   "references": [
     {
       "type": "ADVISORY",
@@ -178,13 +118,182 @@
       "url": "http://www.securitytracker.com/id/1036587"
     }
   ],
-  "database_specific": {
-    "cwe_ids": [
-      "CWE-119"
-    ],
-    "severity": "MODERATE",
-    "github_reviewed": true,
-    "github_reviewed_at": "2020-06-16T21:20:17Z",
-    "nvd_published_at": "2016-07-12T19:59:00Z"
-  }
+  "affected": [
+    {
+      "package": {
+        "name": "org.springframework:spring-web",
+        "ecosystem": "Maven",
+        "purl": "pkg:maven/org.springframework/spring-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.14"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "1.0",
+        "1.0-rc1",
+        "1.0.1",
+        "1.1",
+        "1.1-rc1",
+        "1.1-rc2",
+        "1.1.1",
+        "1.1.2",
+        "1.1.3",
+        "1.1.4",
+        "1.1.5",
+        "1.2",
+        "1.2-rc1",
+        "1.2-rc2",
+        "1.2.1",
+        "1.2.2",
+        "1.2.3",
+        "1.2.4",
+        "1.2.5",
+        "1.2.6",
+        "1.2.7",
+        "1.2.8",
+        "1.2.9",
+        "2.0",
+        "2.0-m1",
+        "2.0-m2",
+        "2.0-m3",
+        "2.0-m4",
+        "2.0-m5",
+        "2.0-rc1",
+        "2.0-rc2",
+        "2.0.1",
+        "2.0.2",
+        "2.0.3",
+        "2.0.4",
+        "2.0.5",
+        "2.0.6",
+        "2.0.7",
+        "2.0.8",
+        "2.5",
+        "2.5.1",
+        "2.5.2",
+        "2.5.3",
+        "2.5.4",
+        "2.5.5",
+        "2.5.6",
+        "2.5.6.SEC01",
+        "2.5.6.SEC02",
+        "2.5.6.SEC03",
+        "3.0.0.RELEASE",
+        "3.0.1.RELEASE",
+        "3.0.2.RELEASE",
+        "3.0.3.RELEASE",
+        "3.0.4.RELEASE",
+        "3.0.5.RELEASE",
+        "3.0.6.RELEASE",
+        "3.0.7.RELEASE",
+        "3.1.0.RELEASE",
+        "3.1.1.RELEASE",
+        "3.1.2.RELEASE",
+        "3.1.3.RELEASE",
+        "3.1.4.RELEASE",
+        "3.2.0.RELEASE",
+        "3.2.1.RELEASE",
+        "3.2.10.RELEASE",
+        "3.2.11.RELEASE",
+        "3.2.12.RELEASE",
+        "3.2.13.RELEASE",
+        "3.2.2.RELEASE",
+        "3.2.3.RELEASE",
+        "3.2.4.RELEASE",
+        "3.2.5.RELEASE",
+        "3.2.6.RELEASE",
+        "3.2.7.RELEASE",
+        "3.2.8.RELEASE",
+        "3.2.9.RELEASE"
+      ],
+      "database_specific": {
+        "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2018/10/GHSA-6v7w-535j-rq5m/GHSA-6v7w-535j-rq5m.json"
+      }
+    },
+    {
+      "package": {
+        "name": "org.springframework:spring-web",
+        "ecosystem": "Maven",
+        "purl": "pkg:maven/org.springframework/spring-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.0"
+            },
+            {
+              "fixed": "4.1.7"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "4.0.0.RELEASE",
+        "4.0.1.RELEASE",
+        "4.0.2.RELEASE",
+        "4.0.3.RELEASE",
+        "4.0.4.RELEASE",
+        "4.0.5.RELEASE",
+        "4.0.6.RELEASE",
+        "4.0.7.RELEASE",
+        "4.0.8.RELEASE",
+        "4.0.9.RELEASE",
+        "4.1.0.RELEASE",
+        "4.1.1.RELEASE",
+        "4.1.2.RELEASE",
+        "4.1.3.RELEASE",
+        "4.1.4.RELEASE",
+        "4.1.5.RELEASE",
+        "4.1.6.RELEASE"
+      ],
+      "database_specific": {
+        "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2018/10/GHSA-6v7w-535j-rq5m/GHSA-6v7w-535j-rq5m.json"
+      }
+    },
+    {
+      "package": {
+        "name": "org.springframework:spring-web",
+        "ecosystem": "Maven",
+        "purl": "pkg:maven/org.springframework/spring-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0.RC2"
+            },
+            {
+              "fixed": "5.0.0.RC3"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "5.0.0.RC2"
+      ],
+      "database_specific": {
+        "source": "https://github.com/github/advisory-database/blob/main/advisories/github-reviewed/2018/10/GHSA-6v7w-535j-rq5m/GHSA-6v7w-535j-rq5m.json"
+      }
+    }
+  ],
+  "schema_version": "1.6.0",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+    }
+  ]
 }

--- a/test/data/osv_multi_events.json
+++ b/test/data/osv_multi_events.json
@@ -1,0 +1,190 @@
+{
+  "schema_version": "1.4.0",
+  "id": "GHSA-6v7w-535j-rq5m",
+  "modified": "2024-03-05T18:17:31Z",
+  "published": "2018-10-17T20:29:12Z",
+  "aliases": [
+    "CVE-2015-3192"
+  ],
+  "summary": "Pivotal Spring Framework DoS Attack with XML Input",
+  "details": "Pivotal Spring Framework before 3.2.14 and 4.x before 4.1.7 do not properly process inline DTD declarations when DTD is not entirely disabled, which allows remote attackers to cause a denial of service (memory consumption and out-of-memory errors) via a crafted XML file.",
+  "severity": [
+    {
+      "type": "CVSS_V3",
+      "score": "CVSS:3.0/AV:L/AC:L/PR:N/UI:R/S:U/C:N/I:N/A:H"
+    }
+  ],
+  "affected": [
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework:spring-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "0"
+            },
+            {
+              "fixed": "3.2.14"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework:spring-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "4.0.0"
+            },
+            {
+              "fixed": "4.1.7"
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "package": {
+        "ecosystem": "Maven",
+        "name": "org.springframework:spring-web"
+      },
+      "ranges": [
+        {
+          "type": "ECOSYSTEM",
+          "events": [
+            {
+              "introduced": "5.0.0.RC2"
+            },
+            {
+              "fixed": "5.0.0.RC3"
+            }
+          ]
+        }
+      ],
+      "versions": [
+        "5.0.0.RC2"
+      ]
+    }
+  ],
+  "references": [
+    {
+      "type": "ADVISORY",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2015-3192"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/issues/17727"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/issues/20352"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/0411435bac835de88a80a64b3f67b1b89244e907"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/38b8262e1e2db9be9d2171d81547da5c65ba7e09"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/5a711c05ec750f069235597173084c2ee7962424"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/9c3580d04e84d25a90ef4c249baee1b4e02df15e"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/d79ec68db40c381b8e205af52748ebd3163ee33b"
+    },
+    {
+      "type": "WEB",
+      "url": "https://github.com/spring-projects/spring-framework/commit/e4651d6b50c5bc85c84ff537859c212ac4e33434"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2016:1218"
+    },
+    {
+      "type": "WEB",
+      "url": "https://access.redhat.com/errata/RHSA-2016:1219"
+    },
+    {
+      "type": "ADVISORY",
+      "url": "https://github.com/advisories/GHSA-6v7w-535j-rq5m"
+    },
+    {
+      "type": "PACKAGE",
+      "url": "https://github.com/spring-projects/spring-framework"
+    },
+    {
+      "type": "WEB",
+      "url": "https://jira.spring.io/browse/SPR-13136"
+    },
+    {
+      "type": "WEB",
+      "url": "https://jira.spring.io/browse/SPR-13136?redirect=false"
+    },
+    {
+      "type": "WEB",
+      "url": "https://lists.debian.org/debian-lts-announce/2019/07/msg00012.html"
+    },
+    {
+      "type": "WEB",
+      "url": "https://spring.io/security/cve-2015-3192"
+    },
+    {
+      "type": "WEB",
+      "url": "http://lists.fedoraproject.org/pipermail/package-announce/2015-July/162015.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://lists.fedoraproject.org/pipermail/package-announce/2015-July/162017.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-1592.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-1593.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-2035.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://rhn.redhat.com/errata/RHSA-2016-2036.html"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securityfocus.com/bid/90853"
+    },
+    {
+      "type": "WEB",
+      "url": "http://www.securitytracker.com/id/1036587"
+    }
+  ],
+  "database_specific": {
+    "cwe_ids": [
+      "CWE-119"
+    ],
+    "severity": "MODERATE",
+    "github_reviewed": true,
+    "github_reviewed_at": "2020-06-16T21:20:17Z",
+    "nvd_published_at": "2016-07-12T19:59:00Z"
+  }
+}

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -624,5 +624,9 @@ def test_wolfi_convert(test_aqua_cg_json, test_aqua_wolfi_json):
 
 
 def test_vuln_location():
-    vl = VulnerabilityLocation.from_values("cpe:2.3:a:pivotal_software:spring_framework:3.2.0:*:*:*:*:*:*:*", "3.2.0", "3.2.0", "", "")
+    vl = VulnerabilityLocation.from_values("cpe:2.3:a:pivotal_software:spring_framework:3.2.0:*:*:*:*:*:*:*", "3.2.0",
+                                           "3.2.0", "", "")
     assert vl.version == "3.2.0"
+    vl = VulnerabilityLocation.from_values("cpe:2.3:a:org.springframework:spring-web:*:*:*:*:*:*:*:*", "5.0.0.RC2",
+                                           "*", "", "5.0.0.RC3")
+    assert vl.version == ">=5.0.0.RC2-<5.0.0.RC3"

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -56,6 +56,15 @@ def test_nvd_api_json3():
 
 
 @pytest.fixture
+def test_nvd_api_json4():
+    test_cve_data = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "data", "CVE-2015-3192.json"
+    )
+    with open(test_cve_data, "r") as fp:
+        return json.loads(fp.read())
+
+
+@pytest.fixture
 def test_osv_rust_json():
     test_cve_data = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "data", "osv_rust_data.json"
@@ -387,7 +396,7 @@ def test_convert2(test_cve_wconfig_json):
     assert len(data) == 1
 
 
-def test_nvd_api_convert(test_nvd_api_json1, test_nvd_api_json2, test_nvd_api_json3):
+def test_nvd_api_convert(test_nvd_api_json1, test_nvd_api_json2, test_nvd_api_json3, test_nvd_api_json4):
     nvdlatest = NvdSource()
     data = nvdlatest.convert(test_nvd_api_json1)
     assert len(data) == 1
@@ -408,6 +417,8 @@ def test_nvd_api_convert(test_nvd_api_json1, test_nvd_api_json2, test_nvd_api_js
     assert len(data) == 0
     data = cvesource.convert(data)
     assert len(data) == 0
+    data = nvdlatest.convert(test_nvd_api_json4)
+    assert len(data) == 1
 
 
 @pytest.mark.skip(reason="This downloads and tests with live data")

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -137,6 +137,15 @@ def test_osv_swift2_json():
 
 
 @pytest.fixture
+def test_osv_mevents_json():
+    test_cve_data = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "data", "osv_multi_events.json"
+    )
+    with open(test_cve_data, "r") as fp:
+        return json.loads(fp.read())
+
+
+@pytest.fixture
 def test_aqua_alsa_json():
     test_cve_data = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "data", "ALSA-2022-8580.json"
@@ -489,8 +498,12 @@ def test_osv_convert(
     test_osv_pypi2_json,
     test_osv_swift_json,
     test_osv_swift2_json,
+    test_osv_mevents_json,
 ):
     osvlatest = OSVSource()
+    cve_data = osvlatest.convert(test_osv_mevents_json)
+    assert cve_data
+    assert len(cve_data) == 3
     cve_data = osvlatest.convert(test_osv_swift_json)
     assert cve_data
     assert len(cve_data) == 2

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -504,7 +504,7 @@ def test_osv_convert(
     osvlatest = OSVSource()
     cve_data = osvlatest.convert(test_osv_mevents_json)
     assert cve_data
-    assert len(cve_data) == 3
+    assert len(cve_data) == 4
     cve_data = osvlatest.convert(test_osv_swift_json)
     assert cve_data
     assert len(cve_data) == 2

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -3,6 +3,7 @@ import os
 
 import pytest
 
+from vdb.lib import VulnerabilityLocation
 from vdb.lib.aqua import AquaSource
 from vdb.lib.cve import CVESource
 from vdb.lib.gha import GitHubSource
@@ -620,3 +621,8 @@ def test_wolfi_convert(test_aqua_cg_json, test_aqua_wolfi_json):
     cve_data = aqualatest.convert(test_aqua_wolfi_json)
     assert cve_data
     assert len(cve_data) == 2
+
+
+def test_vuln_location():
+    vl = VulnerabilityLocation.from_values("cpe:2.3:a:pivotal_software:spring_framework:3.2.0:*:*:*:*:*:*:*", "3.2.0", "3.2.0", "", "")
+    assert vl.version == "3.2.0"

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -204,6 +204,8 @@ def test_version_build_compare():
     assert res
     res = utils.version_compare("1.3.0", "1.2.0-beta", "1.3.2.0")
     assert res
+    res = utils.version_compare("4.3.6.RELEASE", "5.0.0.RC1", "5.0.0.RC3")
+    assert not res
 
 
 def test_version_build_diff_compare():

--- a/vdb/lib/__init__.py
+++ b/vdb/lib/__init__.py
@@ -221,6 +221,9 @@ class CvssV3:
             "vector_string": self.vector_string,
         }
 
+    def __repr__(self):
+        return orjson.dumps(self.to_dict()).decode("utf-8", "ignore")
+
 
 class PackageIssue:
     """Package issue class"""
@@ -276,7 +279,7 @@ class PackageIssue:
                 "fixed_location": self.fixed_location,
             },
             option=orjson.OPT_NAIVE_UTC,
-        )
+        ).decode("utf-8", "ignore")
 
 
 class VulnerabilityDetail:
@@ -412,6 +415,9 @@ class VulnerabilityDetail:
             else self.source_update_time,
         }
 
+    def __repr__(self):
+        return orjson.dumps(self.to_dict()).decode("utf-8", "ignore")
+
 
 class Vulnerability:
     """Vulnerability"""
@@ -462,7 +468,7 @@ class Vulnerability:
                 "source_orig_time": self.source_orig_time.strftime("%Y-%m-%dT%H:%M:%S"),
             },
             option=orjson.OPT_NAIVE_UTC,
-        )
+        ).decode("utf-8", "ignore")
 
 
 class VulnerabilityLocation:
@@ -529,7 +535,7 @@ class VulnerabilityLocation:
                 "vendor": str(self.vendor),
             },
             option=orjson.OPT_NAIVE_UTC,
-        )
+        ).decode("utf-8", "ignore")
 
     def to_dict(self):
         return {

--- a/vdb/lib/db.py
+++ b/vdb/lib/db.py
@@ -23,14 +23,12 @@ def build_index(index_pos_list):
         store_end_pos = dp.get("store_end_pos")
         for d in dp.get("index_list"):
             cve_id = d.get("id")
-            min_version = d.get(
-                "mie",
-                d.get("mii"),
-            )
-            max_version = d.get(
-                "mae",
-                d.get("mai"),
-            )
+            min_version = d.get("mie")
+            if (not min_version or min_version == "*") and d.get("mii"):
+                min_version = d.get("mii")
+            max_version = d.get("mae")
+            if (not max_version or max_version == "*") and d.get("mai"):
+                max_version = d.get("mai")
             if not min_version:
                 min_version = "0"
             if not max_version:

--- a/vdb/lib/nvd.py
+++ b/vdb/lib/nvd.py
@@ -6,6 +6,7 @@ import httpx
 import orjson
 
 from vdb.lib import (
+    CPE_FULL_REGEX,
     CustomNamedTemporaryFile,
     CvssV3,
     Vulnerability,
@@ -259,12 +260,20 @@ class NvdSource(VulnerabilitySource):
                     )
             cpe_details_list = []
             for cpe in cpe_list:
+                cpe_uri = cpe["criteria"]
+                all_parts = CPE_FULL_REGEX.match(cpe_uri)
+                # If a single version is mentioned using cpe then use that as a fallback
+                single_version = ""
+                if all_parts and all_parts.group("version") and all_parts.group("version") != "*":
+                    single_version = all_parts.group("version")
+                version_start_including = cpe.get("versionStartIncluding", single_version)
+                version_end_excluding = cpe.get("versionEndExcluding", single_version)
                 detail = {
-                    "cpe_uri": cpe["criteria"],
-                    "mii": cpe.get("versionStartIncluding"),
+                    "cpe_uri": cpe_uri,
+                    "mii": version_start_including,
                     "mie": cpe.get("versionStartExcluding"),
                     "mai": cpe.get("versionEndIncluding"),
-                    "mae": cpe.get("versionEndExcluding"),
+                    "mae": version_end_excluding,
                     "source_update_time": vuln["lastModified"],
                     "source_orig_time": vuln["published"],
                 }

--- a/vdb/lib/nvd.py
+++ b/vdb/lib/nvd.py
@@ -267,13 +267,13 @@ class NvdSource(VulnerabilitySource):
                 if all_parts and all_parts.group("version") and all_parts.group("version") != "*":
                     single_version = all_parts.group("version")
                 version_start_including = cpe.get("versionStartIncluding", single_version)
-                version_end_excluding = cpe.get("versionEndExcluding", single_version)
+                version_end_including = cpe.get("versionEndIncluding", single_version)
                 detail = {
                     "cpe_uri": cpe_uri,
                     "mii": version_start_including,
                     "mie": cpe.get("versionStartExcluding"),
-                    "mai": cpe.get("versionEndIncluding"),
-                    "mae": version_end_excluding,
+                    "mai": version_end_including,
+                    "mae": cpe.get("versionEndExcluding"),
                     "source_update_time": vuln["lastModified"],
                     "source_orig_time": vuln["published"],
                 }


### PR DESCRIPTION
Handle legacy CVEs such as `CVE-2015-3192` where only the CPE uri is present in the API json.