### PR TITLE
Simplified vers compare to reduce false positives with single vers range

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -35,3 +35,4 @@ jobs:
         pytest --cov=vdb test
       env:
         PYTHONPATH: .
+        TEST_VDB_HOME: vdb_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "6.0.1"
+version = "6.0.2"
 description = "AppThreat's vulnerability database and package search library with a built-in sqlite based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/test/data/osv-npm-star-bug.json
+++ b/test/data/osv-npm-star-bug.json
@@ -1,0 +1,128 @@
+{
+    "schema_version": "1.4.0",
+    "id": "GHSA-67hx-6x53-jw92",
+    "modified": "2024-04-04T14:26:10Z",
+    "published": "2023-10-16T13:55:36Z",
+    "aliases": [
+      "CVE-2023-45133"
+    ],
+    "summary": "Babel vulnerable to arbitrary code execution when compiling specifically crafted malicious code",
+    "details": "### Impact\n\nUsing Babel to compile code that was specifically crafted by an attacker can lead to arbitrary code execution during compilation, when using plugins that rely on the `path.evaluate()`or `path.evaluateTruthy()` internal Babel methods.\n\nKnown affected plugins are:\n- `@babel/plugin-transform-runtime`\n- `@babel/preset-env` when using its [`useBuiltIns`](https://babeljs.io/docs/babel-preset-env#usebuiltins) option\n- Any \"polyfill provider\" plugin that depends on `@babel/helper-define-polyfill-provider`, such as `babel-plugin-polyfill-corejs3`, `babel-plugin-polyfill-corejs2`, `babel-plugin-polyfill-es-shims`, `babel-plugin-polyfill-regenerator`\n\nNo other plugins under the `@babel/` namespace are impacted, but third-party plugins might be.\n\n**Users that only compile trusted code are not impacted.**\n\n### Patches\n\nThe vulnerability has been fixed in `@babel/traverse@7.23.2`.\n\nBabel 6 does not receive security fixes anymore (see [Babel's security policy](https://github.com/babel/babel/security/policy)), hence there is no patch planned for `babel-traverse@6`.\n\n### Workarounds\n\n- Upgrade `@babel/traverse` to v7.23.2 or higher. You can do this by deleting it from your package manager's lockfile and re-installing the dependencies. `@babel/core` >=7.23.2 will automatically pull in a non-vulnerable version.\n- If you cannot upgrade `@babel/traverse` and are using one of the affected packages mentioned above, upgrade them to their latest version to avoid triggering the vulnerable code path in affected `@babel/traverse` versions:\n  - `@babel/plugin-transform-runtime` v7.23.2\n  - `@babel/preset-env` v7.23.2\n  - `@babel/helper-define-polyfill-provider` v0.4.3\n  - `babel-plugin-polyfill-corejs2` v0.4.6\n  - `babel-plugin-polyfill-corejs3` v0.8.5\n  - `babel-plugin-polyfill-es-shims` v0.10.0\n  - `babel-plugin-polyfill-regenerator` v0.5.3",
+    "severity": [
+      {
+        "type": "CVSS_V3",
+        "score": "CVSS:3.1/AV:L/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H"
+      }
+    ],
+    "affected": [
+      {
+        "package": {
+          "ecosystem": "npm",
+          "name": "@babel/traverse"
+        },
+        "ranges": [
+          {
+            "type": "ECOSYSTEM",
+            "events": [
+              {
+                "introduced": "0"
+              },
+              {
+                "fixed": "7.23.2"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "npm",
+          "name": "@babel/traverse"
+        },
+        "ranges": [
+          {
+            "type": "ECOSYSTEM",
+            "events": [
+              {
+                "introduced": "8.0.0-alpha.0"
+              },
+              {
+                "fixed": "8.0.0-alpha.4"
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "package": {
+          "ecosystem": "npm",
+          "name": "babel-traverse"
+        },
+        "ranges": [
+          {
+            "type": "ECOSYSTEM",
+            "events": [
+              {
+                "introduced": "0"
+              }
+            ]
+          }
+        ],
+        "database_specific": {
+          "last_known_affected_version_range": "< 7.23.2"
+        }
+      }
+    ],
+    "references": [
+      {
+        "type": "WEB",
+        "url": "https://github.com/babel/babel/security/advisories/GHSA-67hx-6x53-jw92"
+      },
+      {
+        "type": "ADVISORY",
+        "url": "https://nvd.nist.gov/vuln/detail/CVE-2023-45133"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/babel/babel/pull/16033"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/babel/babel/commit/b13376b346946e3f62fc0848c1d2a23223314c82"
+      },
+      {
+        "type": "WEB",
+        "url": "https://babeljs.io/blog/2023/10/16/cve-2023-45133"
+      },
+      {
+        "type": "PACKAGE",
+        "url": "https://github.com/babel/babel"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/babel/babel/releases/tag/v7.23.2"
+      },
+      {
+        "type": "WEB",
+        "url": "https://github.com/babel/babel/releases/tag/v8.0.0-alpha.4"
+      },
+      {
+        "type": "WEB",
+        "url": "https://lists.debian.org/debian-lts-announce/2023/10/msg00026.html"
+      },
+      {
+        "type": "WEB",
+        "url": "https://www.debian.org/security/2023/dsa-5528"
+      }
+    ],
+    "database_specific": {
+      "cwe_ids": [
+        "CWE-184",
+        "CWE-697"
+      ],
+      "severity": "CRITICAL",
+      "github_reviewed": true,
+      "github_reviewed_at": "2023-10-16T13:55:36Z",
+      "nvd_published_at": "2023-10-12T17:15:09Z"
+    }
+  }

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -12,7 +12,8 @@ from vdb.lib.gha import GitHubSource
 from vdb.lib.nvd import NvdSource
 from vdb.lib.osv import OSVSource
 
-test_tmp_dir = tempfile.mkdtemp(prefix="vdb6-tests-")
+# Temp directories were not working on macOS GitHub runners
+test_tmp_dir = os.getenv("TEST_VDB_HOME", tempfile.mkdtemp(prefix="vdb6-tests-"))
 db6.get(os.path.join(test_tmp_dir, "data.vdb6"), os.path.join(test_tmp_dir, "index.vdb6"))
 
 

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -2,6 +2,8 @@ import json
 import os
 
 import pytest
+import tempfile
+import shutil
 
 from vdb.lib import VulnerabilityLocation, db6, search
 from vdb.lib.aqua import AquaSource
@@ -9,6 +11,9 @@ from vdb.lib.cve import CVESource
 from vdb.lib.gha import GitHubSource
 from vdb.lib.nvd import NvdSource
 from vdb.lib.osv import OSVSource
+
+test_tmp_dir = tempfile.mkdtemp(prefix="vdb6-tests-")
+db6.get(os.path.join(test_tmp_dir, "data.vdb6"), os.path.join(test_tmp_dir, "index.vdb6"))
 
 
 @pytest.fixture
@@ -159,6 +164,15 @@ def test_osv_mevents_json():
 def test_osv_git_json():
     test_cve_data = os.path.join(
         os.path.dirname(os.path.realpath(__file__)), "data", "osv-git.json"
+    )
+    with open(test_cve_data, "r") as fp:
+        return json.loads(fp.read())
+
+
+@pytest.fixture
+def test_osv_npm_star_json():
+    test_cve_data = os.path.join(
+        os.path.dirname(os.path.realpath(__file__)), "data", "osv-npm-star-bug.json"
     )
     with open(test_cve_data, "r") as fp:
         return json.loads(fp.read())
@@ -795,6 +809,14 @@ def test_osv_convert(
     assert not cve_data
 
 
+def test_osv_convert2(test_osv_npm_star_json):
+    osvlatest = OSVSource()
+
+    # npm star
+    cve_data = osvlatest.convert(test_osv_npm_star_json)
+    assert len(cve_data) == 3
+
+
 def test_aqua_convert(
     test_aqua_alsa_json,
     test_aqua_alas_json,
@@ -870,7 +892,7 @@ def test_aqua_convert(
     results_count = len(list(search.search_by_any("CVE-2020-8022")))
     assert results_count == 0
     results_count = len(list(search.search_by_any("CVE-2022-45406")))
-    assert results_count == 27
+    assert results_count == 26
 
     # ubuntu1
     cve_data = aqualatest.convert(test_aqua_ubuntu1_json)
@@ -1187,3 +1209,6 @@ def test_vuln_location():
         "5.0.0.RC3",
     )
     assert vl.version == ">=5.0.0.RC2-<5.0.0.RC3"
+
+
+shutil.rmtree(test_tmp_dir, ignore_errors=True)

--- a/test/test_source.py
+++ b/test/test_source.py
@@ -14,6 +14,7 @@ from vdb.lib.osv import OSVSource
 
 # Temp directories were not working on macOS GitHub runners
 test_tmp_dir = os.getenv("TEST_VDB_HOME", tempfile.mkdtemp(prefix="vdb6-tests-"))
+os.makedirs(test_tmp_dir, exist_ok=True)
 db6.get(os.path.join(test_tmp_dir, "data.vdb6"), os.path.join(test_tmp_dir, "index.vdb6"))
 
 

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -133,6 +133,10 @@ def test_version_compare():
     assert not res
     res = utils.version_compare("12.1.0.2.0", "*", "12.1.0.2", None, None)
     assert res
+    res = utils.version_compare("7.24.1", "0.0.0", None, None, "7.23.2")
+    assert not res
+    res = utils.version_compare("7.24.1", "8.0.0-alpha.0", None, None, "8.0.0-alpha.4")
+    assert not res
 
 
 def test_version_compare_go():
@@ -229,6 +233,10 @@ def test_version_build_compare1():
     assert res
     res = utils.version_compare("2.1.5.1-rc3", "2.1.5.1-rc2", "2.1.5.1-rc6")
     assert res
+    res = utils.version_compare("7.24.1", "0.0.0", "7.23.2")
+    assert not res
+    res = utils.version_compare("7.24.1", "8.0.0-alpha.0", "8.0.0-alpha.4")
+    assert not res
 
 
 def test_version_build_diff_compare():
@@ -984,3 +992,11 @@ def test_url_to_purl():
         "qualifiers": None,
         "subpath": None,
     }
+
+
+def test_vers_compare():
+    assert not utils.vers_compare('7.24.1', 'vers:npm/<7.23.2')
+    assert utils.vers_compare("1.12", "vers:rpm/<=1.12.8-24.el8_8.1")
+    assert not utils.vers_compare("1.13.0", "vers:rpm/<=1.12.8-24.el8_8.1")
+    assert utils.vers_compare("5.5", "vers:deb/<5.6~rc2")
+    assert not utils.vers_compare("5.7", "vers:deb/<5.6~rc2")

--- a/vdb/lib/db6.py
+++ b/vdb/lib/db6.py
@@ -31,7 +31,10 @@ def get(db_file: str = config.VDB_BIN_FILE, index_file: str = config.VDB_BIN_IND
         db_file = f"file:{DB_FILE_SEP}{os.path.abspath(db_file)}"
     if not index_file.startswith("file:"):
         index_file = f"file:{DB_FILE_SEP}{os.path.abspath(index_file)}"
-    flags = apsw.SQLITE_OPEN_URI | apsw.SQLITE_OPEN_NOFOLLOW | (apsw.SQLITE_OPEN_READONLY if read_only else apsw.SQLITE_OPEN_CREATE | apsw.SQLITE_OPEN_READWRITE)
+    rw_flags = apsw.SQLITE_OPEN_URI | apsw.SQLITE_OPEN_NOFOLLOW | apsw.SQLITE_OPEN_CREATE | apsw.SQLITE_OPEN_READWRITE
+    ro_flags = apsw.SQLITE_OPEN_URI | apsw.SQLITE_OPEN_NOFOLLOW | apsw.SQLITE_OPEN_READONLY
+    # To avoid apsw.CantOpenError, we support readonly mode only if the db exists
+    flags = ro_flags if read_only and os.path.exists(db_file) and os.path.exists(index_file) else rw_flags
     if not db_conn:
         db_conn = apsw.Connection(db_file, flags=flags)
     if not index_conn:

--- a/vdb/lib/utils.py
+++ b/vdb/lib/utils.py
@@ -470,17 +470,16 @@ def vers_compare(compare_ver: str | int | float, vers: str) -> bool:
                 and single_version.removeprefix("!=") == compare_ver
             ):
                 return False
-        else:
-            for apart in vers_parts:
-                apart = apart.strip().replace(" ", "")
-                if apart.startswith(">="):
-                    min_version = apart.removeprefix(">=")
-                elif apart.startswith(">"):
-                    min_excluding = apart.removeprefix(">")
-                if apart.startswith("<="):
-                    max_version = apart.removeprefix("<=")
-                elif apart.startswith("<"):
-                    max_excluding = apart.removeprefix("<")
+        for apart in vers_parts:
+            apart = apart.strip().replace(" ", "")
+            if apart.startswith(">="):
+                min_version = apart.removeprefix(">=")
+            elif apart.startswith(">"):
+                min_excluding = apart.removeprefix(">")
+            if apart.startswith("<="):
+                max_version = apart.removeprefix("<=")
+            elif apart.startswith("<"):
+                max_excluding = apart.removeprefix("<")
     return version_compare(
         compare_ver, min_version, max_version, min_excluding, max_excluding
     )


### PR DESCRIPTION
An unwanted else block in utils.vers_compare was resulting in false positives while dealing with single version specifiers. This negatively affected ecosystems such as npm.