### PR TITLE
Support for ignoring specific distro feeds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,5 @@ dmypy.json
 .coverage
 reports/
 .mise.toml
+out.txt
+bom.json

--- a/README.md
+++ b/README.md
@@ -104,15 +104,7 @@ Cache application vulnerabilities
 vdb --cache
 ```
 
-The typical size of this database is over 1.1 GB.
-
-Cache application and OS vulnerabilities
-
-```shell
-vdb --cache-os
-```
-
-Note the size of the database with OS vulnerabilities is over 5 GB.
+The typical size of this database is over 700 MB.
 
 Cache from just [OSV](https://osv.dev)
 
@@ -124,6 +116,23 @@ It is possible to customize the cache behavior by increasing the historic data p
 
 - NVD_START_YEAR - Default: 2018. Supports up to 2002
 - GITHUB_PAGE_COUNT - Default: 2. Supports up to 20
+
+Cache application and OS vulnerabilities
+
+```shell
+vdb --cache-os
+```
+
+Note the size of the database with OS vulnerabilities is over 7.5 GB. It is possible to ignore/exlude specific OS distros using environment variables.
+
+Example to ignore almalinux and ubuntu data from getting included, set the below environment variables:
+
+```shell
+export VDB_IGNORE_ALMALINUX=true
+export VDB_IGNORE_UBUNTU=true
+```
+
+Refer to the variable `LINUX_DISTRO_VULN_LIST_PATHS` in [config.py](./vdb/lib/config.py) for the full list of distro strings supported.
 
 ## CLI Usage
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-vulnerability-db"
-version = "6.0.12"
+version = "6.0.13"
 description = "AppThreat's vulnerability database and package search library with a built-in sqlite based storage. OSV, CVE, GitHub, npm are the primary sources of vulnerabilities."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},

--- a/vdb/lib/aqua.py
+++ b/vdb/lib/aqua.py
@@ -5,6 +5,7 @@ This module fetches the vulnerability data from aquasec vuln-list repo and store
 """
 
 import os
+
 from datetime import datetime
 from zipfile import ZipFile
 
@@ -22,6 +23,49 @@ from vdb.lib.utils import (
 
 # Size of the stream to read and write to the file
 DOWNLOAD_CHUNK_SIZE = 4096
+
+# Some sources are included by default
+DEFAULT_INCLUDE_SOURCE_PATTERNS = ["alpine-unfixed"] if os.getenv("VDB_IGNORE_ALPINE", "") not in ("true", "1") else []
+
+# Some sources are ignored by default
+DEFAULT_IGNORE_SOURCE_PATTERNS = [
+    "alpine",
+    "cwe",
+    "ghsa",
+    "go",
+    "osv",
+    "redhat-cpe",
+    "kevc",
+    "oval",
+    "glad",
+    "mariner",
+]
+
+# Suse is ignored by default for performance reasons
+if os.getenv("VDB_INCLUDE_SUSE", "") not in ("true", "1"):
+    DEFAULT_IGNORE_SOURCE_PATTERNS.append(f"cvrf{os.sep}suse{os.sep}suse")
+
+
+def get_include_source_patterns():
+    """
+    Constructs include patterns by looking up certain distro-specific environment variables
+    """
+    include_paths = DEFAULT_INCLUDE_SOURCE_PATTERNS
+    for name, paths in config.LINUX_DISTRO_VULN_LIST_PATHS.items():
+        if os.getenv(f"VDB_INCLUDE_{name.upper()}", "") in ("true", "1"):
+            include_paths += paths
+    return include_paths
+
+
+def get_ignored_source_patterns():
+    """
+    Constructs ignore patterns by looking up certain distro-specific environment variables
+    """
+    ignore_paths = DEFAULT_IGNORE_SOURCE_PATTERNS
+    for name, paths in config.LINUX_DISTRO_VULN_LIST_PATHS.items():
+        if os.getenv(f"VDB_IGNORE_{name.upper()}", "") in ("true", "1") or os.getenv(f"VDB_EXCLUDE_{name.upper()}", "") in ("true", "1"):
+            ignore_paths += paths
+    return ignore_paths
 
 
 class AquaSource(NvdSource):
@@ -96,22 +140,11 @@ class AquaSource(NvdSource):
 
     @staticmethod
     def is_supported_source(zfname):
-        for distro in ("alpine-unfixed",):
+        # Include has preference over ignore
+        for distro in get_include_source_patterns():
             if distro in zfname:
                 return True
-        for distro in (
-            "alpine",
-            "cwe",
-            "ghsa",
-            "go",
-            "osv",
-            "redhat-cpe",
-            "kevc",
-            "oval",
-            "glad",
-            "mariner",
-            f"cvrf{os.sep}suse{os.sep}suse",
-        ):
+        for distro in get_ignored_source_patterns():
             if distro in zfname:
                 return False
         nvd_start_year = config.NVD_START_YEAR

--- a/vdb/lib/config.py
+++ b/vdb/lib/config.py
@@ -70,13 +70,13 @@ osv_url_dict = {
 
 
 # Support for disabling individual distro feeds
-if not os.getenv("VDB_IGNORE_ALMALINUX"):
+if os.getenv("VDB_IGNORE_ALMALINUX", "") not in ("true", "1"):
     osv_url_dict["almalinux"] = "https://osv-vulnerabilities.storage.googleapis.com/AlmaLinux/all.zip"
-if not os.getenv("VDB_IGNORE_ALPINE"):
+if os.getenv("VDB_IGNORE_ALPINE", "") not in ("true", "1"):
     osv_url_dict["alpine"] = "https://osv-vulnerabilities.storage.googleapis.com/Alpine/all.zip"
-if not os.getenv("VDB_IGNORE_DEBIAN"):
+if os.getenv("VDB_IGNORE_DEBIAN", "") not in ("true", "1"):
     osv_url_dict["debian"] = "https://osv-vulnerabilities.storage.googleapis.com/Debian/all.zip"
-if not os.getenv("VDB_IGNORE_ROCKYLINUX"):
+if os.getenv("VDB_IGNORE_ROCKYLINUX", "") not in ("true", "1"):
     osv_url_dict["rockylinux"] = "https://osv-vulnerabilities.storage.googleapis.com/Rocky%20Linux/all.zip"
 
 

--- a/vdb/lib/config.py
+++ b/vdb/lib/config.py
@@ -63,14 +63,22 @@ osv_url_dict = {
     "pub": "https://osv-vulnerabilities.storage.googleapis.com/Pub/all.zip",
     "uvi": "https://osv-vulnerabilities.storage.googleapis.com/UVI/all.zip",
     "github": "https://osv-vulnerabilities.storage.googleapis.com/GitHub%20Actions/all.zip",
-    "alpine": "https://osv-vulnerabilities.storage.googleapis.com/Alpine/all.zip",
-    "debian": "https://osv-vulnerabilities.storage.googleapis.com/Debian/all.zip",
     "cran": "https://osv-vulnerabilities.storage.googleapis.com/CRAN/all.zip",
-    "almalinux": "https://osv-vulnerabilities.storage.googleapis.com/AlmaLinux/all.zip",
-    "rockylinux": "https://osv-vulnerabilities.storage.googleapis.com/Rocky%20Linux/all.zip",
     "swift": "https://osv-vulnerabilities.storage.googleapis.com/SwiftURL/all.zip",
     "git": "https://osv-vulnerabilities.storage.googleapis.com/GIT/all.zip",
 }
+
+
+# Support for disabling individual distro feeds
+if not os.getenv("VDB_IGNORE_ALMALINUX"):
+    osv_url_dict["almalinux"] = "https://osv-vulnerabilities.storage.googleapis.com/AlmaLinux/all.zip"
+if not os.getenv("VDB_IGNORE_ALPINE"):
+    osv_url_dict["alpine"] = "https://osv-vulnerabilities.storage.googleapis.com/Alpine/all.zip"
+if not os.getenv("VDB_IGNORE_DEBIAN"):
+    osv_url_dict["debian"] = "https://osv-vulnerabilities.storage.googleapis.com/Debian/all.zip"
+if not os.getenv("VDB_IGNORE_ROCKYLINUX"):
+    osv_url_dict["rockylinux"] = "https://osv-vulnerabilities.storage.googleapis.com/Rocky%20Linux/all.zip"
+
 
 # These feeds introduce too much false positives
 if os.getenv("OSV_INCLUDE_FUZZ"):
@@ -164,3 +172,22 @@ VDB_DATABASE_URL = os.getenv(
 
 # A smaller application vulnerabilities database
 VDB_APP_ONLY_DATABASE_URL = os.getenv("VDB_APP_ONLY_DATABASE_URL", "ghcr.io/appthreat/vdbxz-app:v6")
+
+# This variable can be used to include or exclude distro-specific data
+# export VDB_IGNORE_ALMALINUX=true
+# export VDB_INCLUDE_ALPINE=true
+LINUX_DISTRO_VULN_LIST_PATHS = {
+    "almalinux": ["alma"],
+    "alpine": ["alpine", "alpine-unfixed"],
+    "amazon": ["amazon"],
+    "arch": ["arch-linux"],
+    "chainguard": ["chainguard"],
+    "opensuse": [f"cvrf{os.sep}suse{os.sep}opensuse"],
+    "suse": [f"cvrf{os.sep}suse{os.sep}suse"],
+    "debian": ["debian"],
+    "photon": ["photon"],
+    "redhat": ["redhat"],
+    "rocky": ["rocky"],
+    "ubuntu": ["ubuntu"],
+    "wolfi": ["wolfi"]
+}

--- a/vdb/lib/db6.py
+++ b/vdb/lib/db6.py
@@ -113,3 +113,16 @@ def needs_update(days=1, hours=0, minutes=0, seconds=0, default_status=False):
     created_time = datetime.fromisoformat(db_metadata["created_utc"])
     diff = current_time - created_time
     return diff > timedelta(days=days, hours=hours, minutes=minutes, seconds=seconds)
+
+
+def is_app_only_database():
+    """
+    Method to check if the pre-compiled database includes only application vulnerabilities. To avoid the need for a SQL
+    query, this method checks the sources list in the file metadata for AquaSource.
+
+    Defaults to False, if the metadata file is not found.
+    """
+    db_metadata = get_db_file_metadata()
+    if not db_metadata:
+        return False
+    return "AquaSource" not in db_metadata.get("sources", [])


### PR DESCRIPTION
Fixes #174. Users wishing to include suse can set the below environment variable

```
export VDB_INCLUDE_SUSE=true
```

The PR also adds support to ignore individual distros. 